### PR TITLE
Add chat command

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
@@ -172,7 +171,7 @@ func previewRequest(req *http.Request, noColor bool) error {
 	fmt.Println("\nRequest Headers:")
 	fmt.Printf("  Content-Type: application/json\n")
 	if cfg.GleanToken != "" {
-		fmt.Printf("  Authorization: Bearer %s\n", maskToken(cfg.GleanToken))
+		fmt.Printf("  Authorization: Bearer %s\n", config.MaskToken(cfg.GleanToken))
 	}
 	if cfg.GleanEmail != "" {
 		fmt.Printf("  X-Glean-User-Email: %s\n", cfg.GleanEmail)
@@ -194,13 +193,6 @@ func previewRequest(req *http.Request, noColor bool) error {
 	}
 
 	return nil
-}
-
-func maskToken(token string) string {
-	if len(token) <= 8 {
-		return strings.Repeat("*", len(token))
-	}
-	return token[:4] + strings.Repeat("*", len(token)-8) + token[len(token)-4:]
 }
 
 func isatty(fd uintptr) bool {

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -120,7 +120,7 @@ func NewCmdAPI() *cobra.Command {
 			}
 
 			// Only show spinner if we're in a terminal and not using --raw or --no-color
-			useSpinner := isatty(os.Stderr.Fd()) && !opts.raw && !opts.noColor
+			useSpinner := term.IsTerminal(int(os.Stderr.Fd())) && !opts.raw && !opts.noColor
 
 			var s *spinner.Spinner
 			if useSpinner {
@@ -193,8 +193,4 @@ func previewRequest(req *http.Request, noColor bool) error {
 	}
 
 	return nil
-}
-
-func isatty(fd uintptr) bool {
-	return term.IsTerminal(int(fd))
 }

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -1,0 +1,206 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/scalvert/glean-cli/pkg/config"
+	"github.com/scalvert/glean-cli/pkg/http"
+	"github.com/spf13/cobra"
+)
+
+type ChatMessage struct {
+	Author      string `json:"author"`
+	MessageType string `json:"messageType"`
+	Fragments   []struct {
+		Text string `json:"text"`
+	} `json:"fragments"`
+}
+
+type ChatRequest struct {
+	AgentConfig   AgentConfig   `json:"agentConfig"`
+	ApplicationID string        `json:"applicationId,omitempty"`
+	ChatID        string        `json:"chatId,omitempty"`
+	Messages      []ChatMessage `json:"messages"`
+	TimeoutMillis int           `json:"timeoutMillis"`
+	Stream        bool          `json:"stream"`
+	SaveChat      bool          `json:"saveChat"`
+}
+
+type AgentConfig struct {
+	Agent string `json:"agent"`
+	Mode  string `json:"mode"`
+}
+
+type ChatResponse struct {
+	ChatSessionTrackingToken string `json:"chatSessionTrackingToken"`
+	Messages                 []struct {
+		Author    string `json:"author"`
+		Fragments []struct {
+			Text string `json:"text"`
+		} `json:"fragments"`
+		HasMoreFragments bool `json:"hasMoreFragments,omitempty"`
+	} `json:"messages"`
+}
+
+// cleanMarkdown removes markdown formatting from text
+func cleanMarkdown(text string) string {
+	// Remove bold/italic markers
+	text = regexp.MustCompile(`\*\*`).ReplaceAllString(text, "")
+	text = regexp.MustCompile(`\*`).ReplaceAllString(text, "")
+	text = regexp.MustCompile(`__`).ReplaceAllString(text, "")
+	text = regexp.MustCompile(`_`).ReplaceAllString(text, "")
+
+	// Convert markdown links to plain text
+	text = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`).ReplaceAllString(text, "$1")
+
+	// Remove backticks
+	text = regexp.MustCompile("`").ReplaceAllString(text, "")
+
+	// Remove multiple blank lines
+	text = regexp.MustCompile(`\n\s*\n\s*\n`).ReplaceAllString(text, "\n\n")
+
+	return text
+}
+
+func NewCmdChat() *cobra.Command {
+	var timeoutMillis int
+	var saveChat bool
+
+	cmd := &cobra.Command{
+		Use:   "chat [message]",
+		Short: "Have a conversation with Glean's chat API",
+		Long: `Have a conversation with Glean's chat API.
+
+The chat API allows you to have natural language conversations with Glean's AI.
+The response will be streamed as it becomes available.
+
+Example:
+  glean chat "What are the company holidays?"
+  glean chat --timeout 60000 "Tell me about the engineering team"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeChat(cmd, args[0], timeoutMillis, saveChat)
+		},
+	}
+
+	cmd.Flags().IntVar(&timeoutMillis, "timeout", 30000, "Request timeout in milliseconds")
+	cmd.Flags().BoolVar(&saveChat, "save", true, "Save the chat for later continuation")
+
+	return cmd
+}
+
+func executeChat(cmd *cobra.Command, question string, timeoutMillis int, saveChat bool) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	client, err := http.NewClient(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Create chat request
+	req := ChatRequest{
+		Messages: []ChatMessage{
+			{
+				Author:      "USER",
+				MessageType: "CONTENT",
+				Fragments: []struct {
+					Text string `json:"text"`
+				}{
+					{Text: question},
+				},
+			},
+		},
+		Stream: true,
+		AgentConfig: AgentConfig{
+			Agent: "DEFAULT",
+			Mode:  "DEFAULT",
+		},
+		SaveChat:      saveChat,
+		TimeoutMillis: timeoutMillis,
+	}
+
+	// Convert request to JSON
+	jsonBytes, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("error marshaling request: %w", err)
+	}
+
+	// Create HTTP request
+	httpReq := &http.Request{
+		Method: "POST",
+		Path:   "chat",
+		Body:   json.RawMessage(jsonBytes),
+		Stream: true,
+	}
+
+	// Start spinner
+	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	spin.Prefix = "Waiting for response "
+	spin.Start()
+	defer spin.Stop()
+
+	// Send request and get streaming response
+	responseBody, err := client.SendStreamingRequest(httpReq)
+	if err != nil {
+		return err
+	}
+	defer responseBody.Close()
+
+	// Create a reader for the streaming response
+	reader := bufio.NewReader(responseBody)
+	firstLine := true
+
+	// Read response line by line
+	for {
+		line, err := reader.ReadString('\n')
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error reading response: %w", err)
+		}
+
+		// Skip empty lines
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		// Stop spinner after first line
+		if firstLine {
+			spin.Stop()
+			firstLine = false
+		}
+
+		// Parse and print the response
+		var chatResp ChatResponse
+		if err := json.Unmarshal([]byte(line), &chatResp); err != nil {
+			return fmt.Errorf("error parsing response line: %w", err)
+		}
+
+		// Print each message
+		for _, msg := range chatResp.Messages {
+			for _, fragment := range msg.Fragments {
+				cleanedText := cleanMarkdown(fragment.Text)
+				if cleanedText != "" {
+					fmt.Fprint(cmd.OutOrStdout(), cleanedText)
+					if !msg.HasMoreFragments {
+						fmt.Fprintln(cmd.OutOrStdout())
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/chat_test.go
+++ b/cmd/chat_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/scalvert/glean-cli/pkg/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatCommand(t *testing.T) {
+	t.Run("basic chat response", func(t *testing.T) {
+		// Create a response with multiple streaming messages
+		response := []byte(`{"messages":[{"author":"GLEAN_AI","fragments":[{"text":"Hello"}],"hasMoreFragments":false}],"chatSessionTrackingToken":"token1"}
+{"messages":[{"author":"GLEAN_AI","fragments":[{"text":"How"}],"hasMoreFragments":true}],"chatSessionTrackingToken":"token2"}
+{"messages":[{"author":"GLEAN_AI","fragments":[{"text":" can"}],"hasMoreFragments":true}],"chatSessionTrackingToken":"token3"}
+{"messages":[{"author":"GLEAN_AI","fragments":[{"text":" I"}],"hasMoreFragments":true}],"chatSessionTrackingToken":"token4"}
+{"messages":[{"author":"GLEAN_AI","fragments":[{"text":" help?"}],"hasMoreFragments":false}],"chatSessionTrackingToken":"token5"}`)
+
+		_, cleanup := testutils.SetupTestWithResponse(t, response)
+		defer cleanup()
+
+		b := bytes.NewBufferString("")
+		cmd := NewCmdChat()
+		cmd.SetOut(b)
+		cmd.SetArgs([]string{"What can you do?"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+
+		output := b.String()
+		assert.Contains(t, output, "Hello")
+		assert.Contains(t, output, "How can I help?")
+	})
+
+	t.Run("chat with error response", func(t *testing.T) {
+		// Create an error response that's not in the expected ChatResponse format
+		response := []byte(`{"error": "Something went wrong"}\n`)
+		_, cleanup := testutils.SetupTestWithResponse(t, response)
+		defer cleanup()
+
+		b := bytes.NewBufferString("")
+		cmd := NewCmdChat()
+		cmd.SetOut(b)
+		cmd.SetArgs([]string{"Test error"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing response line")
+	})
+
+	t.Run("chat with invalid JSON response", func(t *testing.T) {
+		response := []byte(`invalid json`)
+		_, cleanup := testutils.SetupTestWithResponse(t, response)
+		defer cleanup()
+
+		b := bytes.NewBufferString("")
+		cmd := NewCmdChat()
+		cmd.SetOut(b)
+		cmd.SetArgs([]string{"Test invalid"})
+
+		err := cmd.Execute()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing response line")
+	})
+
+	t.Run("chat with empty response", func(t *testing.T) {
+		response := []byte(``)
+		_, cleanup := testutils.SetupTestWithResponse(t, response)
+		defer cleanup()
+
+		b := bytes.NewBufferString("")
+		cmd := NewCmdChat()
+		cmd.SetOut(b)
+		cmd.SetArgs([]string{"Test empty"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Empty(t, b.String())
+	})
+
+	t.Run("chat with timeout flag", func(t *testing.T) {
+		response := []byte(`{"messages":[{"author":"GLEAN_AI","fragments":[{"text":"Quick response"}],"hasMoreFragments":false}],"chatSessionTrackingToken":"token1"}`)
+		_, cleanup := testutils.SetupTestWithResponse(t, response)
+		defer cleanup()
+
+		b := bytes.NewBufferString("")
+		cmd := NewCmdChat()
+		cmd.SetOut(b)
+		cmd.SetArgs([]string{"--timeout", "60000", "Test timeout"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, b.String(), "Quick response")
+	})
+
+	t.Run("chat with save flag disabled", func(t *testing.T) {
+		response := []byte(`{"messages":[{"author":"GLEAN_AI","fragments":[{"text":"Not saved"}],"hasMoreFragments":false}],"chatSessionTrackingToken":"token1"}`)
+		_, cleanup := testutils.SetupTestWithResponse(t, response)
+		defer cleanup()
+
+		b := bytes.NewBufferString("")
+		cmd := NewCmdChat()
+		cmd.SetOut(b)
+		cmd.SetArgs([]string{"--save=false", "Test no save"})
+
+		err := cmd.Execute()
+		require.NoError(t, err)
+		assert.Contains(t, b.String(), "Not saved")
+	})
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/scalvert/glean-cli/pkg/config"
@@ -59,7 +58,7 @@ func NewCmdConfig() *cobra.Command {
 				// Mask token if present
 				tokenDisplay := notSetValue
 				if cfg.GleanToken != "" {
-					tokenDisplay = cfg.GleanToken[0:4] + strings.Repeat("*", len(cfg.GleanToken)-4)
+					tokenDisplay = config.MaskToken(cfg.GleanToken)
 				}
 				fmt.Printf("  %-10s %s\n", "Token:", tokenDisplay)
 				return nil

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -22,5 +22,9 @@ func NewCmdGenerate() *cobra.Command {
 			}
 		},
 	}
+
+	// Add subcommands
+	cmd.AddCommand(NewCmdOpenAPISpec())
+
 	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,10 @@ func NewCmdRoot() *cobra.Command {
 				fmt.Fprintf(os.Stderr, "Error displaying help: %v\n", err)
 			}
 		},
+		// Silence usage output when an error occurs
+		SilenceUsage: true,
+		// Ensure consistent error formatting
+		SilenceErrors: true,
 	}
 
 	// Add all subcommands
@@ -32,9 +36,15 @@ func NewCmdRoot() *cobra.Command {
 		NewCmdAPI(),
 		NewCmdConfig(),
 		NewCmdGenerate(),
-		NewCmdOpenAPISpec(),
 		NewCmdSearch(),
+		NewCmdChat(),
 	)
+
+	// Propagate settings to all subcommands
+	for _, subCmd := range cmd.Commands() {
+		subCmd.SilenceUsage = true
+		subCmd.SilenceErrors = true
+	}
 
 	return cmd
 }
@@ -44,5 +54,9 @@ func init() {
 }
 
 func Execute() error {
-	return rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return err
+	}
+	return nil
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -8,15 +8,83 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/mattn/go-tty"
 	"github.com/scalvert/glean-cli/pkg/config"
 	"github.com/scalvert/glean-cli/pkg/http"
+	"github.com/scalvert/glean-cli/pkg/output"
 	"github.com/spf13/cobra"
 )
 
-var testMode bool
-var testInput string
+// Test mode configuration
+var (
+	testMode  bool
+	testInput string
+)
 
+// Default template for search results
+var defaultTemplate = `{{- range $i, $result := .Results -}}
+{{if $i}}
+
+{{end}}{{add $i 1}} {{formatDatasource $result.Document.Datasource}} | {{gleanBlue $result.Document.Title}}
+{{gleanYellow $result.Document.URL}}
+{{- range $result.Snippets}}
+{{.Text}}{{end}}
+{{- end}}{{if .SuggestedSpellCorrectedQuery}}
+
+Did you mean: {{.SuggestedSpellCorrectedQuery}}?{{end}}{{if .RewrittenQuery}}
+
+Showing results for: {{.RewrittenQuery}}{{end}}`
+
+// Core domain types
+type Document struct {
+	ParentDocument *Document         `json:"parentDocument,omitempty"`
+	Metadata       *DocumentMetadata `json:"metadata"`
+	ID             string            `json:"id"`
+	Datasource     string            `json:"datasource"`
+	DocType        string            `json:"docType"`
+	Title          string            `json:"title"`
+	URL            string            `json:"url"`
+}
+
+type DocumentMetadata struct {
+	Datasource         string                 `json:"datasource"`
+	DatasourceInstance string                 `json:"datasourceInstance"`
+	ObjectType         string                 `json:"objectType"`
+	Container          string                 `json:"container,omitempty"`
+	ContainerId        string                 `json:"containerId,omitempty"`
+	MimeType           string                 `json:"mimeType"`
+	DocumentId         string                 `json:"documentId"`
+	LoggingId          string                 `json:"loggingId"`
+	CreateTime         string                 `json:"createTime"`
+	UpdateTime         string                 `json:"updateTime"`
+	Author             *Person                `json:"author,omitempty"`
+	Owner              *Person                `json:"owner,omitempty"`
+	Visibility         string                 `json:"visibility"`
+	Status             string                 `json:"status,omitempty"`
+	AssignedTo         *Person                `json:"assignedTo,omitempty"`
+	DatasourceId       string                 `json:"datasourceId"`
+	Interactions       map[string]interface{} `json:"interactions"`
+	DocumentCategory   string                 `json:"documentCategory"`
+	CustomData         map[string]interface{} `json:"customData,omitempty"`
+	Shortcuts          []Shortcut             `json:"shortcuts,omitempty"`
+}
+
+type Person struct {
+	Metadata     *PersonMetadata `json:"metadata,omitempty"`
+	Name         string          `json:"name"`
+	ObfuscatedId string          `json:"obfuscatedId"`
+}
+
+type PersonMetadata struct {
+	RelatedDocuments []RelatedDocument `json:"relatedDocuments,omitempty"`
+}
+
+type RelatedDocument struct {
+	// Add fields as needed
+}
+
+// Request types
 type SearchOptions struct {
 	InputDetails      *SearchInputDetails `json:"inputDetails,omitempty"`
 	SessionInfo       *SessionInfo        `json:"sessionInfo,omitempty"`
@@ -39,20 +107,6 @@ type SearchOptions struct {
 
 type SearchInputDetails struct {
 	HasCopyPaste bool `json:"hasCopyPaste,omitempty"`
-}
-
-type Person struct {
-	Metadata     *PersonMetadata `json:"metadata,omitempty"`
-	Name         string          `json:"name"`
-	ObfuscatedId string          `json:"obfuscatedId"`
-}
-
-type PersonMetadata struct {
-	RelatedDocuments []RelatedDocument `json:"relatedDocuments,omitempty"`
-}
-
-type RelatedDocument struct {
-	// Add fields as needed
 }
 
 type RequestOptions struct {
@@ -108,39 +162,6 @@ type SessionInfo struct {
 	TabId                string `json:"tabId,omitempty"`
 }
 
-type Document struct {
-	ParentDocument *Document         `json:"parentDocument,omitempty"`
-	Metadata       *DocumentMetadata `json:"metadata"`
-	ID             string            `json:"id"`
-	Datasource     string            `json:"datasource"`
-	DocType        string            `json:"docType"`
-	Title          string            `json:"title"`
-	URL            string            `json:"url"`
-}
-
-type DocumentMetadata struct {
-	Datasource         string                 `json:"datasource"`
-	DatasourceInstance string                 `json:"datasourceInstance"`
-	ObjectType         string                 `json:"objectType"`
-	Container          string                 `json:"container,omitempty"`
-	ContainerId        string                 `json:"containerId,omitempty"`
-	MimeType           string                 `json:"mimeType"`
-	DocumentId         string                 `json:"documentId"`
-	LoggingId          string                 `json:"loggingId"`
-	CreateTime         string                 `json:"createTime"`
-	UpdateTime         string                 `json:"updateTime"`
-	Author             *Person                `json:"author,omitempty"`
-	Owner              *Person                `json:"owner,omitempty"`
-	Visibility         string                 `json:"visibility"`
-	Status             string                 `json:"status,omitempty"`
-	AssignedTo         *Person                `json:"assignedTo,omitempty"`
-	DatasourceId       string                 `json:"datasourceId"`
-	Interactions       map[string]interface{} `json:"interactions"`
-	DocumentCategory   string                 `json:"documentCategory"`
-	CustomData         map[string]interface{} `json:"customData,omitempty"`
-	Shortcuts          []Shortcut             `json:"shortcuts,omitempty"`
-}
-
 type Shortcut struct {
 	InputAlias     string `json:"inputAlias"`
 	DestinationUrl string `json:"destinationUrl"`
@@ -150,74 +171,6 @@ type Shortcut struct {
 	ViewPrefix     string `json:"viewPrefix"`
 	Alias          string `json:"alias"`
 	Title          string `json:"title"`
-}
-
-var defaultTemplate = `{{- range $i, $result := .Results -}}
-{{if $i}}
-
-{{end}}{{add $i 1}} {{formatDatasource $result.Document.Datasource}} | {{gleanBlue $result.Document.Title}}
-{{gleanYellow $result.Document.URL}}
-{{- range $result.Snippets}}
-{{.Text}}{{end}}
-{{- end}}{{if .SuggestedSpellCorrectedQuery}}
-
-Did you mean: {{.SuggestedSpellCorrectedQuery}}?{{end}}{{if .RewrittenQuery}}
-
-Showing results for: {{.RewrittenQuery}}{{end}}`
-
-func NewCmdSearch() *cobra.Command {
-	opts := &SearchOptions{
-		RequestOptions: &RequestOptions{
-			FacetBucketSize: 10,
-			ResponseHints:   []string{"RESULTS", "QUERY_METADATA"},
-		},
-	}
-
-	cmd := &cobra.Command{
-		Use:   "search [query]",
-		Short: "Search for content in your Glean instance",
-		Long: `Search for content in your Glean instance.
-
-You can search for any content that is indexed in your Glean instance.
-The results will be displayed in a formatted list by default.
-
-Example:
-  glean search "vacation policy"
-  glean search --page-size 20 "engineering docs"
-  glean search --template "{{range .Results}}{{.Title}}\n{{end}}" "meeting notes"`,
-		Args: cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Query = args[0]
-			return runSearch(cmd, opts)
-		},
-	}
-
-	// Basic search options
-	cmd.Flags().IntVarP(&opts.PageSize, "page-size", "n", 10, "Number of results per page")
-	cmd.Flags().BoolVar(&opts.DisableSpellcheck, "disable-spellcheck", false, "Disable spellcheck suggestions")
-	cmd.Flags().IntVar(&opts.MaxSnippetSize, "max-snippet-size", 200, "Maximum length of result snippets")
-	cmd.Flags().IntVar(&opts.TimeoutMillis, "timeout", 30000, "Request timeout in milliseconds")
-
-	// Output formatting
-	cmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Go template for formatting results")
-	cmd.Flags().StringVarP(&opts.OutputFormat, "output", "o", "text", "Output format: text, json")
-	cmd.Flags().BoolVar(&opts.NoColor, "no-color", false, "Disable colorized output")
-
-	// Filtering options
-	cmd.Flags().StringSliceP("datasource", "d", nil, "Filter by datasource (can be specified multiple times)")
-	cmd.Flags().StringSliceP("type", "y", nil, "Filter by document type (can be specified multiple times)")
-	cmd.Flags().StringSliceP("person", "p", nil, "Filter by person email (can be specified multiple times)")
-	cmd.Flags().StringSlice("tab", nil, "Filter by result tab IDs (can be specified multiple times)")
-
-	// Advanced options
-	cmd.Flags().Bool("disable-query-autocorrect", false, "Disable automatic query corrections")
-	cmd.Flags().Bool("fetch-all-datasource-counts", false, "Return result counts for all supported datasources")
-	cmd.Flags().Bool("query-overrides-facet-filters", false, "Let query operators override facet filters")
-	cmd.Flags().Bool("return-llm-content", false, "Return expanded content for LLM usage")
-	cmd.Flags().StringSlice("response-hints", []string{"RESULTS", "QUERY_METADATA"}, "Response hints (RESULTS, QUERY_METADATA, etc)")
-	cmd.Flags().Int("facet-bucket-size", 10, "Maximum number of facet buckets to return")
-
-	return cmd
 }
 
 // Additional response types
@@ -236,8 +189,9 @@ type FacetResult struct {
 }
 
 type FacetBucket struct {
-	Value string `json:"value"`
-	Count int    `json:"count"`
+	Value       interface{} `json:"value"`
+	DisplayName string      `json:"displayName,omitempty"`
+	Count       int         `json:"count"`
 }
 
 type GeneratedQna struct {
@@ -327,17 +281,90 @@ type SearchMetadata struct {
 	ObjectType string  `json:"objectType,omitempty"`
 }
 
+// NewCmdSearch creates and returns the search command
+func NewCmdSearch() *cobra.Command {
+	opts := &SearchOptions{
+		RequestOptions: &RequestOptions{
+			FacetBucketSize: 10,
+			ResponseHints:   []string{"RESULTS", "QUERY_METADATA"},
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "search [query]",
+		Short: "Search for content in your Glean instance",
+		Long: `Search for content in your Glean instance.
+
+You can search for any content that is indexed in your Glean instance.
+The results will be displayed in a formatted list by default.
+
+Example:
+  glean search "vacation policy"
+  glean search --page-size 20 "engineering docs"
+  glean search --template "{{range .Results}}{{.Title}}\n{{end}}" "meeting notes"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Query = args[0]
+			return runSearch(cmd, opts)
+		},
+	}
+
+	// Basic search options
+	cmd.Flags().IntVarP(&opts.PageSize, "page-size", "n", 10, "Number of results per page")
+	cmd.Flags().BoolVar(&opts.DisableSpellcheck, "disable-spellcheck", false, "Disable spellcheck suggestions")
+	cmd.Flags().IntVar(&opts.MaxSnippetSize, "max-snippet-size", 200, "Maximum length of result snippets")
+	cmd.Flags().IntVar(&opts.TimeoutMillis, "timeout", 30000, "Request timeout in milliseconds")
+
+	// Output formatting
+	cmd.Flags().StringVarP(&opts.Template, "template", "t", "", "Go template for formatting results")
+	cmd.Flags().StringVarP(&opts.OutputFormat, "output", "o", "text", "Output format: text, json")
+	cmd.Flags().BoolVar(&opts.NoColor, "no-color", false, "Disable colorized output")
+
+	// Filtering options
+	cmd.Flags().StringSliceP("datasource", "d", nil, "Filter by datasource (can be specified multiple times)")
+	cmd.Flags().StringSliceP("type", "y", nil, "Filter by document type (can be specified multiple times)")
+	cmd.Flags().StringSliceP("person", "p", nil, "Filter by person email (can be specified multiple times)")
+	cmd.Flags().StringSlice("tab", nil, "Filter by result tab IDs (can be specified multiple times)")
+
+	// Advanced options
+	cmd.Flags().Bool("disable-query-autocorrect", false, "Disable automatic query corrections")
+	cmd.Flags().Bool("fetch-all-datasource-counts", false, "Return result counts for all supported datasources")
+	cmd.Flags().Bool("query-overrides-facet-filters", false, "Let query operators override facet filters")
+	cmd.Flags().Bool("return-llm-content", false, "Return expanded content for LLM usage")
+	cmd.Flags().StringSlice("response-hints", []string{"RESULTS", "QUERY_METADATA"}, "Response hints (RESULTS, QUERY_METADATA, etc)")
+	cmd.Flags().Int("facet-bucket-size", 10, "Maximum number of facet buckets to return")
+
+	return cmd
+}
+
+// runSearch executes the search command with the given options
 func runSearch(cmd *cobra.Command, opts *SearchOptions) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	client, err := http.NewClient(cfg)
+	if err != nil {
+		return err
+	}
+
+	// Start spinner
+	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	spin.Prefix = "Searching Company Knowledge "
+	spin.Start()
+	defer spin.Stop()
+
 	// Handle facet filters
-	if datasources, err := cmd.Flags().GetStringSlice("datasource"); err == nil && len(datasources) > 0 {
+	if datasources, flagErr := cmd.Flags().GetStringSlice("datasource"); flagErr == nil && len(datasources) > 0 {
 		addFacetFilter(opts, "datasource", datasources)
 	}
-	if types, err := cmd.Flags().GetStringSlice("type"); err == nil && len(types) > 0 {
+	if types, flagErr := cmd.Flags().GetStringSlice("type"); flagErr == nil && len(types) > 0 {
 		addFacetFilter(opts, "type", types)
 	}
 
 	// Handle person filters
-	if people, err := cmd.Flags().GetStringSlice("person"); err == nil && len(people) > 0 {
+	if people, flagErr := cmd.Flags().GetStringSlice("person"); flagErr == nil && len(people) > 0 {
 		opts.People = make([]Person, len(people))
 		for i, email := range people {
 			opts.People[i] = Person{
@@ -347,7 +374,7 @@ func runSearch(cmd *cobra.Command, opts *SearchOptions) error {
 	}
 
 	// Handle result tab filters
-	if tabs, err := cmd.Flags().GetStringSlice("tab"); err == nil && len(tabs) > 0 {
+	if tabs, flagErr := cmd.Flags().GetStringSlice("tab"); flagErr == nil && len(tabs) > 0 {
 		opts.ResultTabIds = tabs
 	}
 
@@ -360,47 +387,48 @@ func runSearch(cmd *cobra.Command, opts *SearchOptions) error {
 	opts.RequestOptions.TimezoneOffset = getTimezoneOffset()
 
 	// Set facet bucket size
-	if size, err := cmd.Flags().GetInt("facet-bucket-size"); err == nil {
+	if size, flagErr := cmd.Flags().GetInt("facet-bucket-size"); flagErr == nil {
 		opts.RequestOptions.FacetBucketSize = size
 	}
 
 	// Set response hints
-	if hints, err := cmd.Flags().GetStringSlice("response-hints"); err == nil {
+	if hints, flagErr := cmd.Flags().GetStringSlice("response-hints"); flagErr == nil {
 		opts.RequestOptions.ResponseHints = hints
 	}
 
 	// Set boolean flags
-	if disable, err := cmd.Flags().GetBool("disable-query-autocorrect"); err == nil {
+	if disable, flagErr := cmd.Flags().GetBool("disable-query-autocorrect"); flagErr == nil {
 		opts.RequestOptions.DisableQueryAutocorrect = disable
 	}
-	if fetch, err := cmd.Flags().GetBool("fetch-all-datasource-counts"); err == nil {
+	if fetch, flagErr := cmd.Flags().GetBool("fetch-all-datasource-counts"); flagErr == nil {
 		opts.RequestOptions.FetchAllDatasourceCounts = fetch
 	}
-	if override, err := cmd.Flags().GetBool("query-overrides-facet-filters"); err == nil {
+	if override, flagErr := cmd.Flags().GetBool("query-overrides-facet-filters"); flagErr == nil {
 		opts.RequestOptions.QueryOverridesFacetFilters = override
 	}
-	if llm, err := cmd.Flags().GetBool("return-llm-content"); err == nil {
+	if llm, flagErr := cmd.Flags().GetBool("return-llm-content"); flagErr == nil {
 		opts.RequestOptions.ReturnLlmContentOverSnippets = llm
 	}
 
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	client, err := http.NewClient(cfg)
+	// Perform search
+	resp, err := performSearch(client, opts, "", "")
 	if err != nil {
 		return err
 	}
 
-	// Initial search request
-	response, err := performSearch(client, opts, "", "")
-	if err != nil {
-		return err
-	}
+	// Stop spinner before writing output
+	spin.Stop()
 
+	// Format and write output
 	if opts.OutputFormat == "json" {
-		return json.NewEncoder(cmd.OutOrStdout()).Encode(response)
+		jsonBytes, marshalErr := json.Marshal(resp)
+		if marshalErr != nil {
+			return fmt.Errorf("error marshaling JSON: %w", marshalErr)
+		}
+		return output.Write(cmd.OutOrStdout(), jsonBytes, output.Options{
+			NoColor: opts.NoColor,
+			Format:  "json",
+		})
 	}
 
 	// Use template for output
@@ -430,13 +458,13 @@ func runSearch(cmd *cobra.Command, opts *SearchOptions) error {
 	}
 
 	// Print initial results
-	err = t.Execute(cmd.OutOrStdout(), response)
+	err = t.Execute(cmd.OutOrStdout(), resp)
 	if err != nil {
 		return fmt.Errorf("error executing template: %w", err)
 	}
 
 	// Handle pagination if needed
-	for response.HasMoreResults {
+	for resp.HasMoreResults {
 		fmt.Fprint(cmd.OutOrStdout(), "\n\nPress 'q' to quit, any other key to load more results...")
 
 		if testMode {
@@ -471,12 +499,12 @@ func runSearch(cmd *cobra.Command, opts *SearchOptions) error {
 			}
 		}
 
-		response, err = performSearch(client, opts, response.Cursor, response.TrackingToken)
+		resp, err = performSearch(client, opts, resp.Cursor, resp.TrackingToken)
 		if err != nil {
 			return err
 		}
 
-		err = t.Execute(cmd.OutOrStdout(), response)
+		err = t.Execute(cmd.OutOrStdout(), resp)
 		if err != nil {
 			return fmt.Errorf("error executing template: %w", err)
 		}
@@ -485,7 +513,7 @@ func runSearch(cmd *cobra.Command, opts *SearchOptions) error {
 	return nil
 }
 
-// getTimezoneOffset returns the local timezone offset in minutes from UTC
+// Helper functions
 func getTimezoneOffset() int {
 	_, offset := time.Now().Zone()
 	return offset / 60 // Convert seconds to minutes
@@ -503,6 +531,23 @@ func addFacetFilter(opts *SearchOptions, fieldName string, values []string) {
 		}
 	}
 	opts.RequestOptions.FacetFilters = append(opts.RequestOptions.FacetFilters, filter)
+}
+
+func formatDatasource(s string) string {
+	if s == "nonindexedshortcut" {
+		return "GoLink"
+	}
+
+	words := []rune(s)
+	if len(words) > 0 {
+		words[0] = []rune(strings.ToUpper(string(words[0])))[0]
+	}
+	for i := 1; i < len(words); i++ {
+		if words[i-1] == ' ' {
+			words[i] = []rune(strings.ToUpper(string(words[i])))[0]
+		}
+	}
+	return string(words)
 }
 
 func performSearch(client http.Client, opts *SearchOptions, cursor, trackingToken string) (*SearchResponse, error) {
@@ -560,21 +605,4 @@ func performSearch(client http.Client, opts *SearchOptions, cursor, trackingToke
 	}
 
 	return &searchResp, nil
-}
-
-func formatDatasource(s string) string {
-	if s == "nonindexedshortcut" {
-		return "GoLink"
-	}
-
-	words := []rune(s)
-	if len(words) > 0 {
-		words[0] = []rune(strings.ToUpper(string(words[0])))[0]
-	}
-	for i := 1; i < len(words); i++ {
-		if words[i-1] == ' ' {
-			words[i] = []rune(strings.ToUpper(string(words[i])))[0]
-		}
-	}
-	return string(words)
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/scalvert/glean-cli/cmd"
@@ -10,7 +9,6 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,15 @@ import (
 	"github.com/zalando/go-keyring"
 )
 
+// MaskToken masks a token by showing only the first and last 4 characters
+// and replacing the rest with asterisks.
+func MaskToken(token string) string {
+	if len(token) <= 8 {
+		return strings.Repeat("*", len(token))
+	}
+	return token[:4] + strings.Repeat("*", len(token)-8) + token[len(token)-4:]
+}
+
 // keyringProvider defines the interface for keyring operations
 type keyringProvider interface {
 	Get(service, key string) (string, error)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -34,11 +35,13 @@ func (s *systemKeyring) Delete(service, key string) error {
 // keyringImpl is the current keyring implementation, can be swapped for testing
 var keyringImpl keyringProvider = &systemKeyring{}
 
+// ServiceName is the service name used for keyring operations
+var ServiceName = "glean-cli"
+
 const (
-	serviceName = "glean-cli"
-	hostKey     = "host"
-	tokenKey    = "token"
-	emailKey    = "email"
+	hostKey  = "host"
+	tokenKey = "token"
+	emailKey = "email"
 )
 
 // ConfigPath is the path to the config file. This can be overridden for testing.
@@ -52,9 +55,9 @@ func init() {
 }
 
 type Config struct {
-	GleanHost  string
-	GleanToken string
-	GleanEmail string
+	GleanHost  string `json:"host"`
+	GleanToken string `json:"token"`
+	GleanEmail string `json:"email"`
 }
 
 func ValidateAndTransformHost(host string) (string, error) {
@@ -73,59 +76,168 @@ func ValidateAndTransformHost(host string) (string, error) {
 	return host, nil
 }
 
-func LoadConfig() (*Config, error) {
+// loadFromKeyring attempts to load config from the system keyring
+func loadFromKeyring() *Config {
 	cfg := &Config{}
 
-	if host, err := keyringImpl.Get(serviceName, hostKey); err == nil {
+	if host, err := keyringImpl.Get(ServiceName, hostKey); err == nil {
 		cfg.GleanHost = host
 	}
 
-	if token, err := keyringImpl.Get(serviceName, tokenKey); err == nil {
+	if token, err := keyringImpl.Get(ServiceName, tokenKey); err == nil {
 		cfg.GleanToken = token
 	}
 
-	if email, err := keyringImpl.Get(serviceName, emailKey); err == nil {
+	if email, err := keyringImpl.Get(ServiceName, emailKey); err == nil {
 		cfg.GleanEmail = email
+	}
+
+	return cfg
+}
+
+// loadFromFile attempts to load config from the config file
+func loadFromFile() (*Config, error) {
+	if ConfigPath == "" {
+		return nil, fmt.Errorf("config path not set")
+	}
+
+	data, err := os.ReadFile(ConfigPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Config{}, nil
+		}
+		return nil, fmt.Errorf("error reading config file: %w", err)
+	}
+
+	var cfg Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// LoadConfig loads the configuration from keyring first, falling back to config file
+func LoadConfig() (*Config, error) {
+	// Try keyring first
+	cfg := loadFromKeyring()
+
+	// If no values were loaded from keyring, try config file
+	if cfg.GleanHost == "" && cfg.GleanToken == "" && cfg.GleanEmail == "" {
+		var err error
+		cfg, err = loadFromFile()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil
 }
 
+// saveToFile saves the config to the local config file
+func saveToFile(cfg *Config) error {
+	if ConfigPath == "" {
+		return fmt.Errorf("config path not set")
+	}
+
+	// Ensure the directory exists
+	if err := os.MkdirAll(filepath.Dir(ConfigPath), 0700); err != nil {
+		return fmt.Errorf("error creating config directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("error marshaling config: %w", err)
+	}
+
+	if err := os.WriteFile(ConfigPath, data, 0600); err != nil {
+		return fmt.Errorf("error writing config file: %w", err)
+	}
+
+	return nil
+}
+
+// SaveConfig saves the configuration to both keyring and config file
 func SaveConfig(host, token, email string) error {
 	if host != "" {
 		validHost, err := ValidateAndTransformHost(host)
 		if err != nil {
 			return err
 		}
-		if err := keyringImpl.Set(serviceName, hostKey, validHost); err != nil {
-			return err
-		}
+		host = validHost
 	}
 
+	// Try to save to keyring first
+	var keyringErr error
+	if host != "" {
+		if err := keyringImpl.Set(ServiceName, hostKey, host); err != nil {
+			keyringErr = err
+		}
+	}
 	if token != "" {
-		if err := keyringImpl.Set(serviceName, tokenKey, token); err != nil {
-			return err
+		if err := keyringImpl.Set(ServiceName, tokenKey, token); err != nil {
+			keyringErr = err
+		}
+	}
+	if email != "" {
+		if err := keyringImpl.Set(ServiceName, emailKey, email); err != nil {
+			keyringErr = err
 		}
 	}
 
+	// Always try to save to file as well
+	cfg := &Config{}
+	existingCfg, err := loadFromFile()
+	if err == nil {
+		cfg = existingCfg
+	}
+
+	if host != "" {
+		cfg.GleanHost = host
+	}
+	if token != "" {
+		cfg.GleanToken = token
+	}
 	if email != "" {
-		if err := keyringImpl.Set(serviceName, emailKey, email); err != nil {
-			return err
-		}
+		cfg.GleanEmail = email
+	}
+
+	if err := saveToFile(cfg); err != nil && keyringErr != nil {
+		// Only return error if both storage methods failed
+		return fmt.Errorf("failed to save config: keyring error: %v, file error: %v", keyringErr, err)
 	}
 
 	return nil
 }
 
+// ClearConfig removes the configuration from both keyring and config file
 func ClearConfig() error {
-	if err := keyringImpl.Delete(serviceName, hostKey); err != nil && err != keyring.ErrNotFound {
-		return err
+	var keyringErr error
+
+	// Clear keyring
+	if err := keyringImpl.Delete(ServiceName, hostKey); err != nil && err != keyring.ErrNotFound {
+		keyringErr = err
 	}
-	if err := keyringImpl.Delete(serviceName, tokenKey); err != nil && err != keyring.ErrNotFound {
-		return err
+	if err := keyringImpl.Delete(ServiceName, tokenKey); err != nil && err != keyring.ErrNotFound {
+		keyringErr = err
 	}
-	if err := keyringImpl.Delete(serviceName, emailKey); err != nil && err != keyring.ErrNotFound {
-		return err
+	if err := keyringImpl.Delete(ServiceName, emailKey); err != nil && err != keyring.ErrNotFound {
+		keyringErr = err
 	}
+
+	// Clear config file
+	if ConfigPath != "" {
+		if err := os.Remove(ConfigPath); err != nil && !os.IsNotExist(err) {
+			if keyringErr != nil {
+				return fmt.Errorf("failed to clear config: keyring error: %v, file error: %v", keyringErr, err)
+			}
+			return fmt.Errorf("error removing config file: %w", err)
+		}
+	}
+
+	if keyringErr != nil {
+		return fmt.Errorf("error clearing keyring: %w", keyringErr)
+	}
+
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -248,7 +248,7 @@ func TestConfigOperations(t *testing.T) {
 		// Simulate keyring failure
 		mock.err = assert.AnError
 
-		// Create config directory with no write permissions
+		// Create config directory
 		configDir := filepath.Dir(configPath)
 		err := os.MkdirAll(configDir, 0700)
 		require.NoError(t, err)
@@ -256,12 +256,15 @@ func TestConfigOperations(t *testing.T) {
 		// Remove any existing config file
 		os.Remove(configPath)
 
-		// Make directory read-only
-		err = os.Chmod(configDir, 0500)
+		// Create a file instead of the config directory to make writes fail
+		err = os.Remove(configDir)
+		require.NoError(t, err)
+		err = os.WriteFile(configDir, []byte("not a directory"), 0600)
 		require.NoError(t, err)
 		defer func() {
-			// Restore permissions for cleanup
-			os.Chmod(configDir, 0700)
+			// Clean up for other tests
+			os.Remove(configDir)
+			os.MkdirAll(configDir, 0700)
 		}()
 
 		err = SaveConfig("linkedin", "test-token", "test@example.com")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,10 +14,18 @@ import (
 
 // mockKeyring implements a file-based mock of the keyring for testing
 type mockKeyring struct {
-	dir string
+	dir         string
+	err         error  // Used to simulate keyring errors
+	serviceName string // Test-specific service name
 }
 
 func (m *mockKeyring) Get(service, key string) (string, error) {
+	if service != m.serviceName {
+		return "", keyring.ErrNotFound
+	}
+	if m.err != nil {
+		return "", m.err
+	}
 	data, err := os.ReadFile(filepath.Join(m.dir, service+"_"+key))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -27,6 +37,12 @@ func (m *mockKeyring) Get(service, key string) (string, error) {
 }
 
 func (m *mockKeyring) Set(service, key, value string) error {
+	if service != m.serviceName {
+		return fmt.Errorf("attempted to write to non-test service: %s", service)
+	}
+	if m.err != nil {
+		return m.err
+	}
 	err := os.MkdirAll(m.dir, 0700)
 	if err != nil {
 		return err
@@ -35,6 +51,12 @@ func (m *mockKeyring) Set(service, key, value string) error {
 }
 
 func (m *mockKeyring) Delete(service, key string) error {
+	if service != m.serviceName {
+		return keyring.ErrNotFound
+	}
+	if m.err != nil {
+		return m.err
+	}
 	err := os.Remove(filepath.Join(m.dir, service+"_"+key))
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -45,21 +67,48 @@ func (m *mockKeyring) Delete(service, key string) error {
 	return nil
 }
 
-func setupTestKeyring(t *testing.T) func() {
+func setupTestKeyring(t *testing.T) (*mockKeyring, func()) {
 	t.Helper()
 
 	// Create a temporary directory for the mock keyring
 	tmpDir := t.TempDir()
 
-	// Store the original keyring implementation
+	// Store the original keyring implementation and service name
 	originalKeyring := keyringImpl
+	originalService := ServiceName
 
-	// Set up the mock keyring
-	keyringImpl = &mockKeyring{dir: tmpDir}
+	// Use a test-specific service name
+	testService := "glean-cli-test"
+	ServiceName = testService
 
-	// Return a cleanup function
-	return func() {
+	// Create and set up the mock keyring
+	mock := &mockKeyring{
+		dir:         tmpDir,
+		serviceName: testService,
+	}
+	keyringImpl = mock
+
+	// Return the mock and cleanup function
+	return mock, func() {
 		keyringImpl = originalKeyring
+		ServiceName = originalService
+	}
+}
+
+func setupTestConfig(t *testing.T) (string, func()) {
+	t.Helper()
+
+	// Create a temporary directory for the config file
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.json")
+
+	// Store the original config path
+	originalPath := ConfigPath
+	ConfigPath = configPath
+
+	// Return the config path and cleanup function
+	return configPath, func() {
+		ConfigPath = originalPath
 	}
 }
 
@@ -121,11 +170,13 @@ func TestConfigPath(t *testing.T) {
 }
 
 func TestConfigOperations(t *testing.T) {
-	// Set up mock keyring and get cleanup function
-	cleanup := setupTestKeyring(t)
-	defer cleanup()
+	// Set up both keyring and config file
+	mock, cleanupKeyring := setupTestKeyring(t)
+	configPath, cleanupConfig := setupTestConfig(t)
+	defer cleanupKeyring()
+	defer cleanupConfig()
 
-	t.Run("save and load config", func(t *testing.T) {
+	t.Run("save and load config with working keyring", func(t *testing.T) {
 		// Save config
 		err := SaveConfig("linkedin", "test-token", "test@example.com")
 		require.NoError(t, err)
@@ -137,16 +188,47 @@ func TestConfigOperations(t *testing.T) {
 		assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost)
 		assert.Equal(t, "test-token", cfg.GleanToken)
 		assert.Equal(t, "test@example.com", cfg.GleanEmail)
+
+		// Verify config file was also created
+		assert.FileExists(t, configPath)
 	})
 
-	t.Run("clear config", func(t *testing.T) {
+	t.Run("fallback to config file when keyring fails", func(t *testing.T) {
+		// First save config successfully
+		err := SaveConfig("linkedin", "test-token", "test@example.com")
+		require.NoError(t, err)
+
+		// Now simulate keyring failure
+		mock.err = assert.AnError
+
+		// Load config should still work using file
+		cfg, err := LoadConfig()
+		require.NoError(t, err)
+
+		assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost)
+		assert.Equal(t, "test-token", cfg.GleanToken)
+		assert.Equal(t, "test@example.com", cfg.GleanEmail)
+	})
+
+	t.Run("clear config removes from both storages", func(t *testing.T) {
 		// First save some config
 		err := SaveConfig("linkedin", "test-token", "test@example.com")
 		require.NoError(t, err)
 
+		// Reset mock error
+		mock.err = nil
+
 		// Clear config
 		err = ClearConfig()
 		require.NoError(t, err)
+
+		// Verify keyring is cleared
+		_, err = keyringImpl.Get(ServiceName, hostKey)
+		assert.Equal(t, keyring.ErrNotFound, err)
+
+		// Verify config file is removed
+		_, err = os.Stat(configPath)
+		assert.True(t, os.IsNotExist(err))
 
 		// Load config should return empty values
 		cfg, err := LoadConfig()
@@ -160,5 +242,74 @@ func TestConfigOperations(t *testing.T) {
 		err := SaveConfig("invalid.example.com", "test-token", "test@example.com")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid host format")
+	})
+
+	t.Run("save with both storages failing", func(t *testing.T) {
+		// Simulate keyring failure
+		mock.err = assert.AnError
+
+		// Create config directory with no write permissions
+		configDir := filepath.Dir(configPath)
+		err := os.MkdirAll(configDir, 0700)
+		require.NoError(t, err)
+
+		// Remove any existing config file
+		os.Remove(configPath)
+
+		// Make directory read-only
+		err = os.Chmod(configDir, 0500)
+		require.NoError(t, err)
+		defer func() {
+			// Restore permissions for cleanup
+			os.Chmod(configDir, 0700)
+		}()
+
+		err = SaveConfig("linkedin", "test-token", "test@example.com")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to save config")
+		assert.Contains(t, err.Error(), "keyring error")
+		assert.Contains(t, err.Error(), "file error")
+
+		// Reset mock error for other tests
+		mock.err = nil
+	})
+}
+
+func TestLoadFromFile(t *testing.T) {
+	_, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	t.Run("load non-existent file returns empty config", func(t *testing.T) {
+		cfg, err := loadFromFile()
+		require.NoError(t, err)
+		assert.Empty(t, cfg.GleanHost)
+		assert.Empty(t, cfg.GleanToken)
+		assert.Empty(t, cfg.GleanEmail)
+	})
+
+	t.Run("load invalid JSON returns error", func(t *testing.T) {
+		err := os.WriteFile(ConfigPath, []byte("invalid json"), 0600)
+		require.NoError(t, err)
+
+		_, err = loadFromFile()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "error parsing config file")
+	})
+
+	t.Run("load valid config file", func(t *testing.T) {
+		cfg := Config{
+			GleanHost:  "test-be.glean.com",
+			GleanToken: "test-token",
+			GleanEmail: "test@example.com",
+		}
+		data, err := json.MarshalIndent(cfg, "", "  ")
+		require.NoError(t, err)
+
+		err = os.WriteFile(ConfigPath, data, 0600)
+		require.NoError(t, err)
+
+		loadedCfg, err := loadFromFile()
+		require.NoError(t, err)
+		assert.Equal(t, cfg, *loadedCfg)
 	})
 }


### PR DESCRIPTION
# Summary

This pull request introduces a new chat command to the `glean-cli` and includes several other improvements and refactorings. The most important changes are the addition of the chat command, associated tests, and improvements to the command structure and error handling.

### New Chat Command:
* [`cmd/chat.go`](diffhunk://#diff-6b0607dd168ceed82e861d12bfe91cc9e8fd1f164653ef927b458579d69c5a8aR1-R206): Added a new chat command that allows users to have conversations with Glean's chat API. This includes defining new types (`ChatMessage`, `ChatRequest`, `ChatResponse`, `AgentConfig`), implementing the `NewCmdChat` function, and the chat execution logic (`executeChat`).

### Tests for Chat Command:
* [`cmd/chat_test.go`](diffhunk://#diff-27a286ca82b61e0c20baeba67d5af192e77b1356924ffa62d9bc8d48d5187adaR1-R112): Added comprehensive tests for the new chat command, covering basic responses, error handling, invalid JSON, empty responses, and different flag options.

### Command Structure Improvements:
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR28-R48): Added the new chat command to the root command, silenced usage output and errors for consistent error formatting, and propagated these settings to all subcommands. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR28-R48) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL47-R61)

### Error Handling Enhancements:
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL47-R61): Modified the `Execute` function to print errors to `stderr` and return the error.

### Refactoring and Cleanup:
* [`cmd/search.go`](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bR11-R87): Refactored the search command by reorganizing types and constants, and improving the structure of the `NewCmdSearch` function. [[1]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bR11-R87) [[2]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bL44-L57) [[3]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bL111-L143) [[4]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bL155-L222) [[5]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bL239-R193) [[6]](diffhunk://#diff-c090fedae21f4dd5aaeeca3e95faefc0fcdde22f01489ea7514c035ccc298d7bR284-R367)