### PR TITLE
feat(config): add support for specifying port

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -15,6 +15,7 @@ const notSetValue = "[not set]"
 // It allows setting or clearing Glean credentials and connection settings.
 type ConfigOptions struct {
 	host  string // Glean instance hostname
+	port  string // Glean instance port
 	token string // API token for authentication
 	email string // User's email address
 	clear bool   // Whether to clear all configuration
@@ -38,6 +39,9 @@ func NewCmdConfig() *cobra.Command {
 			  glean config --host linkedin
 			  glean config --host linkedin-be.glean.com
 
+			  # Set Glean host and port (e.g. custom proxy)
+			  glean config --host foo.bar.com --port 7960
+
 			  # Set Glean API token
 			  glean config --token your-token
 
@@ -59,8 +63,8 @@ func NewCmdConfig() *cobra.Command {
 
 				fmt.Println("Current configuration:")
 				fmt.Printf("  %-10s %s\n", "Host:", valueOrNotSet(cfg.GleanHost))
+				fmt.Printf("  %-10s %s\n", "Port:", valueOrNotSet(cfg.GleanPort))
 				fmt.Printf("  %-10s %s\n", "Email:", valueOrNotSet(cfg.GleanEmail))
-
 				// Mask token if present
 				tokenDisplay := notSetValue
 				if cfg.GleanToken != "" {
@@ -78,11 +82,11 @@ func NewCmdConfig() *cobra.Command {
 				return nil
 			}
 
-			if opts.host == "" && opts.token == "" && opts.email == "" {
-				return fmt.Errorf("no configuration provided. Use --host, --token, or --email to set configuration")
+			if opts.host == "" && opts.port == "" && opts.token == "" && opts.email == "" {
+				return fmt.Errorf("no configuration provided. Use --host, --port, --token, or --email to set configuration")
 			}
 
-			if err := config.SaveConfig(opts.host, opts.token, opts.email); err != nil {
+			if err := config.SaveConfig(opts.host, opts.port, opts.token, opts.email); err != nil {
 				return fmt.Errorf("failed to save configuration: %w", err)
 			}
 
@@ -92,6 +96,7 @@ func NewCmdConfig() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.host, "host", "", "Glean instance name or full hostname (e.g., 'linkedin' or 'linkedin-be.glean.com')")
+	cmd.Flags().StringVar(&opts.port, "port", "", "Glean instance port (e.g., '8080' for custom proxy or local development)")
 	cmd.Flags().StringVar(&opts.token, "token", "", "Glean API token")
 	cmd.Flags().StringVar(&opts.email, "email", "", "Email address for API requests")
 	cmd.Flags().BoolVar(&opts.clear, "clear", false, "Clear all stored credentials")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -130,18 +130,6 @@ func TestValidateAndTransformHost(t *testing.T) {
 			input: "linkedin-be.glean.com",
 			want:  "linkedin-be.glean.com",
 		},
-		{
-			name:        "invalid domain",
-			input:       "linkedin.example.com",
-			wantErr:     true,
-			errContains: "invalid host format",
-		},
-		{
-			name:        "missing -be suffix",
-			input:       "linkedin.glean.com",
-			wantErr:     true,
-			errContains: "invalid host format",
-		},
 	}
 
 	for _, tt := range tests {
@@ -178,7 +166,7 @@ func TestConfigOperations(t *testing.T) {
 
 	t.Run("save and load config with working keyring", func(t *testing.T) {
 		// Save config
-		err := SaveConfig("linkedin", "test-token", "test@example.com")
+		err := SaveConfig("linkedin", "", "test-token", "test@example.com")
 		require.NoError(t, err)
 
 		// Load config
@@ -195,7 +183,7 @@ func TestConfigOperations(t *testing.T) {
 
 	t.Run("fallback to config file when keyring fails", func(t *testing.T) {
 		// First save config successfully
-		err := SaveConfig("linkedin", "test-token", "test@example.com")
+		err := SaveConfig("linkedin", "", "test-token", "test@example.com")
 		require.NoError(t, err)
 
 		// Now simulate keyring failure
@@ -212,7 +200,7 @@ func TestConfigOperations(t *testing.T) {
 
 	t.Run("clear config removes from both storages", func(t *testing.T) {
 		// First save some config
-		err := SaveConfig("linkedin", "test-token", "test@example.com")
+		err := SaveConfig("linkedin", "", "test-token", "test@example.com")
 		require.NoError(t, err)
 
 		// Reset mock error
@@ -238,12 +226,6 @@ func TestConfigOperations(t *testing.T) {
 		assert.Empty(t, cfg.GleanEmail)
 	})
 
-	t.Run("save invalid host", func(t *testing.T) {
-		err := SaveConfig("invalid.example.com", "test-token", "test@example.com")
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid host format")
-	})
-
 	t.Run("save with both storages failing", func(t *testing.T) {
 		// Simulate keyring failure
 		mock.err = assert.AnError
@@ -267,7 +249,7 @@ func TestConfigOperations(t *testing.T) {
 			os.MkdirAll(configDir, 0700)
 		}()
 
-		err = SaveConfig("linkedin", "test-token", "test@example.com")
+		err = SaveConfig("linkedin", "", "test-token", "test@example.com")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to save config")
 		assert.Contains(t, err.Error(), "keyring error")

--- a/internal/http/client.go
+++ b/internal/http/client.go
@@ -56,6 +56,17 @@ func NewClient(cfg *config.Config) (Client, error) {
 	return NewClientFunc(cfg)
 }
 
+func buildBaseURL(cfg *config.Config) string {
+	host := cfg.GleanHost
+	port := cfg.GleanPort
+
+	if port != "" {
+		return fmt.Sprintf("https://%s:%s", host, port)
+	}
+
+	return fmt.Sprintf("https://%s", host)
+}
+
 // defaultNewClient is the default implementation of NewClient
 func defaultNewClient(cfg *config.Config) (Client, error) {
 	if cfg.GleanHost == "" {
@@ -66,7 +77,7 @@ func defaultNewClient(cfg *config.Config) (Client, error) {
 		return nil, fmt.Errorf("Glean token not configured. Run 'glean config --token <token>' to set it")
 	}
 
-	baseURL := fmt.Sprintf("https://%s", cfg.GleanHost)
+	baseURL := buildBaseURL(cfg)
 
 	return &client{
 		http:    &http.Client{},


### PR DESCRIPTION
Often times you might need to configure a custom host or IP (e.g. for a proxy) and you might then need to specify a port for that connection to function. This adds support for that. 

**Note:** This removes the validations of various hosts (e.g. you can specify any host, including an ip address), but it still supports using `--host foo` and having that expand to `foo-be.glean.com`.

- Add port field to ConfigOptions struct
- Update CLI flags and help text to include port option
- Modify HTTP client to use port in base URL construction
- Add support for foo.bar.com host format
- Add tests for port configuration and URL building