### PR TITLE
build(test): replace go test with gotestsum

### DIFF
--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 tasks:
   default:
@@ -54,7 +54,7 @@ tasks:
     desc: Run Go tests
     silent: true
     cmds:
-      - go test ./... -v
+      - gotestsum
 
   test:summary:
     desc: Run Go tests with colorized output and a summary


### PR DESCRIPTION
Replace default Go test command with gotestsum for improved test output formatting:
<img width="237" alt="Screenshot 2025-04-07 at 9 06 31 AM" src="https://github.com/user-attachments/assets/cb0a6a19-a6ba-4007-ae1c-6d67ec0f55be" />
