### PR TITLE
fix: surface actual error when OAuth discovery fails

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -504,7 +504,7 @@ func EmailFromJWT(raw string) string {
 
 // promptForAPIToken handles instances that don't support OAuth.
 func promptForAPIToken(host string) error {
-	fmt.Printf("You can authenticate with an API token instead.\n")
+	fmt.Printf("There was an issue with OAuth. You can try using an API token instead.\n")
 	fmt.Printf("Contact your Glean administrator to generate an API token.\n")
 	fmt.Printf("  (Glean Admin → Settings → API Tokens)\n\n")
 	fmt.Print("Token: ")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -36,13 +35,7 @@ func Login(ctx context.Context) error {
 
 	provider, endpoint, registrationEndpoint, err := discover(ctx, host)
 	if err != nil {
-		var notSupported *ErrOAuthNotSupported
-		if errors.As(err, &notSupported) {
-			fmt.Printf("\nThis Glean instance does not have OAuth configured.\n")
-		} else {
-			fmt.Fprintf(os.Stderr, "\nOAuth discovery failed: %v\n", err)
-			fmt.Fprintf(os.Stderr, "This may be a transient issue — retry with 'glean auth login'.\n")
-		}
+		fmt.Fprintf(os.Stderr, "\nOAuth discovery failed: %v\n", err)
 		return promptForAPIToken(host)
 	}
 
@@ -509,7 +502,7 @@ func EmailFromJWT(raw string) string {
 	return claims.Email
 }
 
-// promptForAPIToken prompts for a manual API token as a fallback.
+// promptForAPIToken handles instances that don't support OAuth.
 func promptForAPIToken(host string) error {
 	fmt.Printf("You can authenticate with an API token instead.\n")
 	fmt.Printf("Contact your Glean administrator to generate an API token.\n")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -35,6 +36,13 @@ func Login(ctx context.Context) error {
 
 	provider, endpoint, registrationEndpoint, err := discover(ctx, host)
 	if err != nil {
+		var notSupported *ErrOAuthNotSupported
+		if errors.As(err, &notSupported) {
+			fmt.Printf("\nThis Glean instance does not have OAuth configured.\n")
+		} else {
+			fmt.Fprintf(os.Stderr, "\nOAuth discovery failed: %v\n", err)
+			fmt.Fprintf(os.Stderr, "This may be a transient issue — retry with 'glean auth login'.\n")
+		}
 		return promptForAPIToken(host)
 	}
 
@@ -501,9 +509,9 @@ func EmailFromJWT(raw string) string {
 	return claims.Email
 }
 
-// promptForAPIToken handles instances that don't support OAuth.
+// promptForAPIToken prompts for a manual API token as a fallback.
 func promptForAPIToken(host string) error {
-	fmt.Printf("\nThis Glean instance doesn't support OAuth.\n")
+	fmt.Printf("You can authenticate with an API token instead.\n")
 	fmt.Printf("Contact your Glean administrator to generate an API token.\n")
 	fmt.Printf("  (Glean Admin → Settings → API Tokens)\n\n")
 	fmt.Print("Token: ")

--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -12,14 +12,13 @@ import (
 
 var discoveryHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
-// ErrOAuthNotSupported indicates the Glean instance does not have OAuth configured.
-// This is distinct from transient failures (network errors, rate limits, etc).
+// ErrOAuthNotSupported is returned when the protected resource endpoint returns 404.
 type ErrOAuthNotSupported struct {
 	URL string
 }
 
 func (e *ErrOAuthNotSupported) Error() string {
-	return fmt.Sprintf("OAuth is not configured at %s", e.URL)
+	return fmt.Sprintf("OAuth protected resource metadata not found at %s", e.URL)
 }
 
 type protectedResourceMetadata struct {
@@ -56,7 +55,7 @@ func fetchProtectedResource(ctx context.Context, baseURL string) (*protectedReso
 		return nil, fmt.Errorf("parsing protected resource metadata: %w", err)
 	}
 	if len(meta.AuthorizationServers) == 0 {
-		return nil, fmt.Errorf("protected resource metadata has no authorization_servers")
+		return nil, fmt.Errorf("server returned OK but OAuth metadata is incomplete (no authorization_servers)")
 	}
 	return &meta, nil
 }

--- a/internal/auth/discovery.go
+++ b/internal/auth/discovery.go
@@ -12,6 +12,16 @@ import (
 
 var discoveryHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
+// ErrOAuthNotSupported indicates the Glean instance does not have OAuth configured.
+// This is distinct from transient failures (network errors, rate limits, etc).
+type ErrOAuthNotSupported struct {
+	URL string
+}
+
+func (e *ErrOAuthNotSupported) Error() string {
+	return fmt.Sprintf("OAuth is not configured at %s", e.URL)
+}
+
 type protectedResourceMetadata struct {
 	Resource             string   `json:"resource"`
 	AuthorizationServers []string `json:"authorization_servers"`
@@ -36,7 +46,7 @@ func fetchProtectedResource(ctx context.Context, baseURL string) (*protectedReso
 	switch resp.StatusCode {
 	case http.StatusOK:
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("OAuth not found at %s — instance may not support OAuth", u)
+		return nil, &ErrOAuthNotSupported{URL: u}
 	default:
 		return nil, fmt.Errorf("protected resource metadata returned HTTP %d", resp.StatusCode)
 	}

--- a/internal/auth/discovery_test.go
+++ b/internal/auth/discovery_test.go
@@ -76,7 +76,7 @@ func TestFetchProtectedResource_EmptyAuthorizationServers(t *testing.T) {
 
 	_, err := fetchProtectedResource(context.Background(), srv.URL)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no authorization_servers")
+	assert.Contains(t, err.Error(), "OAuth metadata is incomplete")
 	var notSupported *ErrOAuthNotSupported
 	assert.False(t, errors.As(err, &notSupported))
 }
@@ -91,14 +91,14 @@ func TestFetchProtectedResource_NullAuthorizationServers(t *testing.T) {
 
 	_, err := fetchProtectedResource(context.Background(), srv.URL)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no authorization_servers")
+	assert.Contains(t, err.Error(), "OAuth metadata is incomplete")
 	var notSupported *ErrOAuthNotSupported
 	assert.False(t, errors.As(err, &notSupported))
 }
 
 func TestErrOAuthNotSupported_ErrorMessage(t *testing.T) {
 	err := &ErrOAuthNotSupported{URL: "https://example.com/.well-known/oauth-protected-resource"}
-	assert.Equal(t, "OAuth is not configured at https://example.com/.well-known/oauth-protected-resource", err.Error())
+	assert.Equal(t, "OAuth protected resource metadata not found at https://example.com/.well-known/oauth-protected-resource", err.Error())
 }
 
 func TestRegisterClient_Success(t *testing.T) {

--- a/internal/auth/discovery_test.go
+++ b/internal/auth/discovery_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -34,7 +35,70 @@ func TestFetchProtectedResource_NotFound(t *testing.T) {
 
 	_, err := fetchProtectedResource(context.Background(), srv.URL)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	var notSupported *ErrOAuthNotSupported
+	assert.True(t, errors.As(err, &notSupported))
+}
+
+func TestFetchProtectedResource_RateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := fetchProtectedResource(context.Background(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "429")
+	var notSupported *ErrOAuthNotSupported
+	assert.False(t, errors.As(err, &notSupported))
+}
+
+func TestFetchProtectedResource_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := fetchProtectedResource(context.Background(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+	var notSupported *ErrOAuthNotSupported
+	assert.False(t, errors.As(err, &notSupported))
+}
+
+func TestFetchProtectedResource_EmptyAuthorizationServers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"resource":              "https://example.glean.com",
+			"authorization_servers": []string{},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := fetchProtectedResource(context.Background(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no authorization_servers")
+	var notSupported *ErrOAuthNotSupported
+	assert.False(t, errors.As(err, &notSupported))
+}
+
+func TestFetchProtectedResource_NullAuthorizationServers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"resource": "https://example.glean.com",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := fetchProtectedResource(context.Background(), srv.URL)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no authorization_servers")
+	var notSupported *ErrOAuthNotSupported
+	assert.False(t, errors.As(err, &notSupported))
+}
+
+func TestErrOAuthNotSupported_ErrorMessage(t *testing.T) {
+	err := &ErrOAuthNotSupported{URL: "https://example.com/.well-known/oauth-protected-resource"}
+	assert.Equal(t, "OAuth is not configured at https://example.com/.well-known/oauth-protected-resource", err.Error())
 }
 
 func TestRegisterClient_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

- Surfaces the actual discovery error to stderr instead of silently discarding it
- Replaces the misleading "This Glean instance doesn't support OAuth" message with an honest acknowledgment that OAuth failed
- Adds `ErrOAuthNotSupported` typed error for distinguishing 404s from other failures at the API level
- Improves error messages in `fetchProtectedResource` to be more descriptive

## Context

When `discover()` fails for any reason, the CLI currently discards the error and shows a static message claiming the instance doesn't support OAuth. This makes it impossible to diagnose login failures — especially when the instance *does* support OAuth and the failure is something else entirely.

Discovered while investigating a customer issue where `glean auth login` failed with the "doesn't support OAuth" message on an instance that clearly has OAuth enabled (admin login works fine, non-admin fails, same machine).

## Before

```
This Glean instance doesn't support OAuth.
Contact your Glean administrator to generate an API token.
  (Glean Admin → Settings → API Tokens)

Token:
```

No indication of what actually went wrong. The error from `discover()` is silently discarded.

## After

```
OAuth discovery failed: server returned OK but OAuth metadata is incomplete (no authorization_servers)

There was an issue with OAuth. You can try using an API token instead.
Contact your Glean administrator to generate an API token.
  (Glean Admin → Settings → API Tokens)

Token:
```

The actual error is printed to stderr, so the user (or support) can see what went wrong. The prompt no longer claims OAuth isn't supported — it acknowledges a problem occurred and offers the API token path.

## Test plan

- [x] New tests for 404, 429, 500, empty `authorization_servers`, null `authorization_servers`, and error message formatting
- [ ] `glean auth login` against an instance with OAuth enabled — should complete normally
- [ ] `glean auth login` against an instance without OAuth — should show actual 404 error and prompt for token
- [ ] `glean auth login` with network disconnected — should show the actual network error