### PR TITLE
feat: use unique OAuth callback path for glean-cli

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -47,7 +47,7 @@ func Login(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("finding callback port: %w", err)
 	}
-	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/callback", port)
+	redirectURI := fmt.Sprintf("http://127.0.0.1:%d/glean-cli-callback", port)
 
 	// Always do fresh DCR per login — the redirect URI (port) changes each time.
 	clientID, clientSecret, err := dcrOrStaticClient(ctx, host, registrationEndpoint, redirectURI)
@@ -94,7 +94,7 @@ func Login(ctx context.Context) error {
 		// LocalServerBindAddress and LocalServerCallbackPath must match the
 		// redirect_uri registered via DCR exactly. oauth2cli constructs the
 		// redirect URL from LocalServerBindAddress (127.0.0.1:{port}) + path.
-		LocalServerCallbackPath: "/callback",
+		LocalServerCallbackPath: "/glean-cli-callback",
 		LocalServerBindAddress:  []string{fmt.Sprintf("127.0.0.1:%d", port)},
 		LocalServerReadyChan:    readyChan,
 		AuthCodeOptions:         []oauth2.AuthCodeOption{oauth2.S256ChallengeOption(verifier)},

--- a/internal/auth/discovery_test.go
+++ b/internal/auth/discovery_test.go
@@ -114,7 +114,7 @@ func TestRegisterClient_Success(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cl, err := registerClient(context.Background(), srv.URL, "http://127.0.0.1:9999/callback")
+	cl, err := registerClient(context.Background(), srv.URL, "http://127.0.0.1:9999/glean-cli-callback")
 	require.NoError(t, err)
 	assert.Equal(t, "dyn-client-id", cl.ClientID)
 }
@@ -129,7 +129,7 @@ func TestRegisterClient_WithSecret(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	cl, err := registerClient(context.Background(), srv.URL, "http://127.0.0.1:9999/callback")
+	cl, err := registerClient(context.Background(), srv.URL, "http://127.0.0.1:9999/glean-cli-callback")
 	require.NoError(t, err)
 	assert.Equal(t, "cs", cl.ClientSecret)
 }


### PR DESCRIPTION
The OAuth redirect URI callback path is changed from `/callback` to `/glean-cli-callback` so that glean-cli's trusted client entry can be matched more definitively. Several other clients use very similar `127.0.0.1:*/callback` patterns in the trusted dynamic client registry, making it hard to distinguish them; a client-specific path eliminates the ambiguity.
