### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gleanwork/gleanwork-reviewers


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` with `* @gleanwork/gleanwork-reviewers`
- Matches the convention used in `glean-developer-site` and other repos in the org

🤖 Generated with [Claude Code](https://claude.com/claude-code)