### PR TITLE
feat: add http:body debug namespace for request/response body logging

### DIFF
--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -1,7 +1,10 @@
 package httputil
 
 import (
+	"bytes"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gleanwork/glean-cli/internal/debug"
@@ -37,9 +40,19 @@ type cliTransport struct {
 }
 
 var (
-	reqLog = debug.New("http:request")
-	resLog = debug.New("http:response")
+	reqLog  = debug.New("http:request")
+	resLog  = debug.New("http:response")
+	bodyLog = debug.New("http:body")
 )
+
+const maxBodyLog = 2000
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "... (truncated)"
+}
 
 func (t *cliTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req = req.Clone(req.Context())
@@ -50,6 +63,14 @@ func (t *cliTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	reqLog.Log("%s %s", req.Method, req.URL.String())
 
+	if bodyLog.Enabled() && req.Body != nil {
+		data, err := io.ReadAll(req.Body)
+		if err == nil {
+			req.Body = io.NopCloser(bytes.NewReader(data))
+			bodyLog.Log("-> %s", truncate(string(data), maxBodyLog))
+		}
+	}
+
 	start := time.Now()
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
@@ -58,6 +79,15 @@ func (t *cliTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	resLog.Log("%d %s (%s)", resp.StatusCode, http.StatusText(resp.StatusCode), time.Since(start).Round(time.Millisecond))
+
+	if bodyLog.Enabled() && resp.Body != nil && !strings.HasPrefix(resp.Header.Get("Content-Type"), "text/event-stream") {
+		data, err := io.ReadAll(resp.Body)
+		if err == nil {
+			resp.Body = io.NopCloser(bytes.NewReader(data))
+			bodyLog.Log("<- %s", truncate(string(data), maxBodyLog))
+		}
+	}
+
 	return resp, nil
 }
 

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gleanwork/glean-cli/internal/debug"
 )
 
 type mockRoundTripper struct {
@@ -119,4 +121,104 @@ func TestNewHTTPClient_SetsTransport(t *testing.T) {
 	require.NotNil(t, client)
 
 	assert.NotNil(t, client.Transport)
+}
+
+func TestTruncate_UnderLimit(t *testing.T) {
+	s := "short string"
+	assert.Equal(t, s, truncate(s, 100))
+}
+
+func TestTruncate_ExactLimit(t *testing.T) {
+	s := "exact"
+	assert.Equal(t, s, truncate(s, 5))
+}
+
+func TestTruncate_OverLimit(t *testing.T) {
+	s := "this is a long string that should be truncated"
+	result := truncate(s, 10)
+	assert.Equal(t, "this is a ... (truncated)", result)
+}
+
+func TestBodyLogging_RequestBodyPreserved(t *testing.T) {
+	debug.Enable()
+	SetVersion("1.0.0")
+
+	requestBody := `{"query":"test"}`
+	var capturedBody string
+	base := &mockRoundTripper{fn: func(req *http.Request) (*http.Response, error) {
+		data, _ := io.ReadAll(req.Body)
+		capturedBody = string(data)
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"result":"ok"}`)),
+		}, nil
+	}}
+
+	transport := NewTransport(base)
+	req, err := http.NewRequest("POST", "https://example.com/api", strings.NewReader(requestBody))
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, requestBody, capturedBody, "request body should be preserved after logging")
+}
+
+func TestBodyLogging_ResponseBodyPreserved(t *testing.T) {
+	debug.Enable()
+	SetVersion("1.0.0")
+
+	responseBody := `{"result":"ok"}`
+	base := &mockRoundTripper{fn: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(responseBody)),
+		}, nil
+	}}
+
+	transport := NewTransport(base)
+	req, err := http.NewRequest("GET", "https://example.com/api", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, responseBody, string(data), "response body should be preserved after logging")
+}
+
+type trackingReadCloser struct {
+	io.ReadCloser
+	read bool
+}
+
+func (t *trackingReadCloser) Read(p []byte) (int, error) {
+	t.read = true
+	return t.ReadCloser.Read(p)
+}
+
+func TestBodyLogging_SSEResponseNotBuffered(t *testing.T) {
+	debug.Enable()
+	SetVersion("1.0.0")
+
+	sseBody := &trackingReadCloser{ReadCloser: io.NopCloser(strings.NewReader("data: hello\n\n"))}
+	base := &mockRoundTripper{fn: func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       sseBody,
+		}, nil
+	}}
+
+	transport := NewTransport(base)
+	req, err := http.NewRequest("GET", "https://example.com/stream", nil)
+	require.NoError(t, err)
+
+	_, err = transport.RoundTrip(req)
+	require.NoError(t, err)
+
+	assert.False(t, sseBody.read, "SSE response body should not be read for logging")
 }


### PR DESCRIPTION
## Summary
- Adds `http:body` debug namespace to the HTTP transport, logging request and response bodies when enabled
- Bodies are truncated to 2000 chars to prevent log flooding
- SSE (`text/event-stream`) responses are explicitly excluded to avoid buffering streams
- Works through the existing `GLEAN_DEBUG` mechanism: `GLEAN_DEBUG=http:body`, `GLEAN_DEBUG=http:*`, or `-v`

## Test plan
- [x] Unit test: truncate helper (under, at, over limit)
- [x] Unit test: request body preserved after logging
- [x] Unit test: response body preserved after logging
- [x] Unit test: SSE response body not buffered (verified via tracking reader)
- [x] `mise run test:all` passes (456 tests, lint clean, binary builds)