### PR TITLE
feat: add atomic file write utility and use it consistently

### DIFF
--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/gleanwork/glean-cli/internal/fileutil"
 )
 
 // StoredTokens holds persisted OAuth tokens for a Glean host.
@@ -53,18 +55,11 @@ func ensureDir(host string) error {
 }
 
 func writeJSON(path string, v any) error {
-	tmp := path + ".tmp"
 	data, err := json.MarshalIndent(v, "", "  ")
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		return err
-	}
-	return os.Chmod(path, 0600)
+	return fileutil.WriteFileAtomic(path, data, 0600)
 }
 
 func readJSON(path string, v any) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gleanwork/glean-cli/internal/debug"
+	"github.com/gleanwork/glean-cli/internal/fileutil"
 	"github.com/zalando/go-keyring"
 )
 
@@ -320,7 +321,7 @@ func saveToFile(cfg *Config) error {
 		return fmt.Errorf("error marshaling config: %w", err)
 	}
 
-	if err := os.WriteFile(ConfigPath, data, 0600); err != nil {
+	if err := fileutil.WriteFileAtomic(ConfigPath, data, 0600); err != nil {
 		return fmt.Errorf("error writing config file: %w", err)
 	}
 

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -1,0 +1,33 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteFileAtomic writes data to path via a temporary file + rename.
+// This prevents corruption from crashes mid-write.
+func WriteFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -1,0 +1,66 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.json")
+	content := []byte(`{"key": "value"}`)
+
+	if err := WriteFileAtomic(path, content, 0600); err != nil {
+		t.Fatalf("WriteFileAtomic failed: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Errorf("permissions = %o, want %o", perm, 0600)
+		}
+	}
+}
+
+func TestWriteFileAtomic_NoLeftoverTmpFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+
+	if err := WriteFileAtomic(path, []byte("hello"), 0644); err != nil {
+		t.Fatalf("WriteFileAtomic failed: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading dir: %v", err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected 1 file, got %d: %v", len(entries), names)
+	}
+}
+
+func TestWriteFileAtomic_NonExistentDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no", "such", "dir", "file.json")
+
+	err := WriteFileAtomic(path, []byte("data"), 0600)
+	if err == nil {
+		t.Fatal("expected error for non-existent directory, got nil")
+	}
+}

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/gleanwork/glean-cli/internal/debug"
+	"github.com/gleanwork/glean-cli/internal/fileutil"
 )
 
 var sessionLog = debug.New("session:persist")
@@ -76,7 +77,7 @@ func (s *Session) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, "latest.json"), data, 0600)
+	return fileutil.WriteFileAtomic(filepath.Join(dir, "latest.json"), data, 0600)
 }
 
 // AddTurn appends a turn to the session and saves immediately.


### PR DESCRIPTION
## Summary
- Extracts the tmp+rename atomic write pattern from `auth/storage.go` into a shared `fileutil.WriteFileAtomic` utility
- Updates `session.Save()`, `config.saveToFile()`, and `auth.writeJSON()` to use it
- Prevents file corruption from crashes or power loss mid-write

## Test plan
- [x] Unit test: write content, verify content and permissions
- [x] Unit test: no leftover tmp files after write
- [x] Unit test: non-existent directory returns error
- [x] Existing auth, config, and session tests pass
- [x] `mise run test:all` passes (453 tests, lint clean, binary builds)