### PR TITLE
feat: add project-level configuration discovery

### DIFF
--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ProjectConfig holds project-level CLI preferences that can be shared
+// via a .glean/config.json file checked into a repository.
+type ProjectConfig struct {
+	DefaultOutput string `json:"default_output,omitempty"`
+	DefaultMode   string `json:"default_mode,omitempty"`
+	DefaultFields string `json:"default_fields,omitempty"`
+}
+
+// FindProjectConfig walks up from the current working directory looking for
+// a .glean/config.json file. Returns nil, nil if no project config is found.
+func FindProjectConfig() (*ProjectConfig, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return nil, nil
+	}
+	return findProjectConfigFrom(dir)
+}
+
+func findProjectConfigFrom(dir string) (*ProjectConfig, error) {
+	for {
+		candidate := filepath.Join(dir, ".glean", "config.json")
+		data, err := os.ReadFile(candidate)
+		if err == nil {
+			var cfg ProjectConfig
+			if err := json.Unmarshal(data, &cfg); err != nil {
+				return nil, fmt.Errorf("invalid %s: %w", candidate, err)
+			}
+			return &cfg, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return nil, nil
+}

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindProjectConfigFrom_Found(t *testing.T) {
+	root := t.TempDir()
+	gleanDir := filepath.Join(root, ".glean")
+	if err := os.MkdirAll(gleanDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"default_output":"json","default_mode":"chat","default_fields":"title,url"}`
+	if err := os.WriteFile(filepath.Join(gleanDir, "config.json"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Search from a nested subdirectory — should walk up and find it.
+	nested := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := findProjectConfigFrom(nested)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config, got nil")
+	}
+	if cfg.DefaultOutput != "json" {
+		t.Errorf("DefaultOutput = %q, want %q", cfg.DefaultOutput, "json")
+	}
+	if cfg.DefaultMode != "chat" {
+		t.Errorf("DefaultMode = %q, want %q", cfg.DefaultMode, "chat")
+	}
+	if cfg.DefaultFields != "title,url" {
+		t.Errorf("DefaultFields = %q, want %q", cfg.DefaultFields, "title,url")
+	}
+}
+
+func TestFindProjectConfigFrom_NotFound(t *testing.T) {
+	root := t.TempDir()
+	cfg, err := findProjectConfigFrom(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config, got %+v", cfg)
+	}
+}
+
+func TestFindProjectConfigFrom_InvalidJSON(t *testing.T) {
+	root := t.TempDir()
+	gleanDir := filepath.Join(root, ".glean")
+	if err := os.MkdirAll(gleanDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gleanDir, "config.json"), []byte(`{bad json`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := findProjectConfigFrom(root)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if cfg != nil {
+		t.Fatalf("expected nil config on error, got %+v", cfg)
+	}
+}
+
+func TestFindProjectConfigFrom_EmptyConfig(t *testing.T) {
+	root := t.TempDir()
+	gleanDir := filepath.Join(root, ".glean")
+	if err := os.MkdirAll(gleanDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gleanDir, "config.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := findProjectConfigFrom(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected config, got nil")
+	}
+	if cfg.DefaultOutput != "" || cfg.DefaultMode != "" || cfg.DefaultFields != "" {
+		t.Errorf("expected all empty fields, got %+v", cfg)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `FindProjectConfig()` that walks up from CWD looking for `.glean/config.json`
- Same filename as global config, differentiated by location (same pattern as Claude Code's `settings.json`)
- `ProjectConfig` struct supports `default_output`, `default_mode`, `default_fields`
- Internal `findProjectConfigFrom()` helper enables testability without changing CWD

## Test plan
- [x] Unit test: found from nested subdirectory
- [x] Unit test: not found returns nil, nil
- [x] Unit test: invalid JSON returns error
- [x] Unit test: empty config parses successfully
- [x] `mise run test:all` passes (454 tests, lint clean, binary builds)