### PR TITLE
fix: route all host normalization through NormalizeHost

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -152,12 +152,7 @@ func NewCmdAPI() *cobra.Command {
 
 // apiBaseURL builds the base API URL from config.
 func apiBaseURL(cfg *config.Config) string {
-	host := cfg.GleanHost
-	// Expand short names (e.g., "linkedin" → "linkedin-be.glean.com")
-	if host != "" && !strings.Contains(host, ".") {
-		host += "-be.glean.com"
-	}
-	return fmt.Sprintf("https://%s", host)
+	return "https://" + config.NormalizeHost(cfg.GleanHost)
 }
 
 // apiFullURL returns the full REST API URL for an endpoint path.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -49,8 +49,9 @@ func ValidateToken(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("no token available")
 	}
 
-	resolveLog.Log("validating token against %s", cfg.GleanHost)
-	url := "https://" + cfg.GleanHost + "/rest/api/v1/search"
+	host := config.NormalizeHost(cfg.GleanHost)
+	resolveLog.Log("validating token against %s", host)
+	url := "https://" + host + "/rest/api/v1/search"
 	body := strings.NewReader(`{"query":"","pageSize":1}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
@@ -93,9 +94,9 @@ func ValidateToken(ctx context.Context, cfg *config.Config) error {
 //  2. System keyring / ~/.glean/config.json (via config.LoadConfig)
 //  3. OAuth token from local storage (via auth.LoadOAuthToken)
 //
-// The GleanHost value is accepted in two forms:
-//   - Full hostname: "linkedin-be.glean.com" → instance = "linkedin"
-//   - Short name:   "linkedin"              → passed as-is to WithInstance
+// GleanHost is normalized via config.NormalizeHost before use. Short names
+// (e.g. "linkedin") are expanded to "linkedin-be.glean.com"; full hostnames
+// and localhost are used as-is.
 func New(cfg *config.Config) (*glean.Glean, error) {
 	if cfg.GleanHost == "" {
 		return nil, fmt.Errorf("glean host not configured. Run 'glean auth login' or set GLEAN_HOST")
@@ -106,11 +107,11 @@ func New(cfg *config.Config) (*glean.Glean, error) {
 		return nil, fmt.Errorf("not authenticated — run 'glean auth login' or set GLEAN_API_TOKEN")
 	}
 
-	instance := extractInstance(cfg.GleanHost)
-	resolveLog.Log("instance=%s authType=%s", instance, authType)
+	host := config.NormalizeHost(cfg.GleanHost)
+	resolveLog.Log("host=%s authType=%s", host, authType)
 
 	opts := []glean.SDKOption{
-		glean.WithInstance(instance),
+		glean.WithServerURL("https://" + host),
 		glean.WithSecurity(token),
 		glean.WithClient(&http.Client{
 			Transport: httputil.NewTransport(http.DefaultTransport,
@@ -134,20 +135,4 @@ func NewFromConfig() (*glean.Glean, error) {
 		return nil, err
 	}
 	return NewFunc(cfg)
-}
-
-// extractInstance derives the Glean instance name from a host value.
-// "linkedin-be.glean.com" → "linkedin"
-// "linkedin"              → "linkedin"
-func extractInstance(host string) string {
-	if strings.HasSuffix(host, "-be.glean.com") {
-		return strings.TrimSuffix(host, "-be.glean.com")
-	}
-	if strings.Contains(host, ".") {
-		// Custom hostname — use as-is; SDK will accept a full URL via WithServerURL
-		// but WithInstance only sets the variable. Return the part before the first dot
-		// as a best-effort fallback.
-		return strings.SplitN(host, ".", 2)[0]
-	}
-	return host
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -72,23 +72,19 @@ func TestResolveToken_NoToken(t *testing.T) {
 	assert.Empty(t, authType)
 }
 
-func TestExtractInstance(t *testing.T) {
-	tests := []struct {
-		host     string
-		expected string
-	}{
-		{"linkedin-be.glean.com", "linkedin"},
-		{"linkedin", "linkedin"},
-		{"custom.example.com", "custom"},
-		{"acme-corp-be.glean.com", "acme-corp"},
-		{"single", "single"},
-		{"deep.sub.domain.example.com", "deep"},
+func TestNew_FullHostname(t *testing.T) {
+	hosts := []string{
+		"acmecorp-be.glean.com",
+		"acmecorp-pl.glean.com",
+		"sub.domain.acmecorp-be.glean.com",
+		"search.acmecorp.com",
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
-			got := extractInstance(tt.host)
-			assert.Equal(t, tt.expected, got)
+	for _, host := range hosts {
+		t.Run(host, func(t *testing.T) {
+			cfg := &config.Config{GleanHost: host, GleanToken: "valid-token"}
+			client, err := New(cfg)
+			require.NoError(t, err)
+			assert.NotNil(t, client)
 		})
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,11 +55,16 @@ func MaskToken(token string) string {
 	return token[:4] + strings.Repeat("*", len(token)-8) + token[len(token)-4:]
 }
 
-// NormalizeHost ensures the Glean host is in the correct format,
-// transforming short names (e.g., "linkedin") to full hostnames (e.g., "linkedin-be.glean.com").
-// Full hostnames (containing a ".") are returned unchanged.
+// NormalizeHost ensures the Glean host is in the correct format.
+// It strips any scheme (https:// or http://) and trailing slashes, then
+// transforms short names (e.g., "linkedin") to full hostnames (e.g., "linkedin-be.glean.com").
+// Full hostnames (containing a ".") and localhost are returned unchanged.
 func NormalizeHost(host string) string {
-	if !strings.Contains(host, ".") {
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimRight(host, "/")
+
+	if !strings.Contains(host, ".") && !strings.HasPrefix(host, "localhost") {
 		return host + "-be.glean.com"
 	}
 	return host

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,7 +127,7 @@ func loadFromEnv() *Config {
 		cfg.GleanToken = v
 	}
 	if v := os.Getenv("GLEAN_HOST"); v != "" {
-		cfg.GleanHost = v
+		cfg.GleanHost = NormalizeHost(v)
 	}
 	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,6 +151,46 @@ func TestValidateAndTransformHost(t *testing.T) {
 			input: "linkedin-be.glean.com",
 			want:  "linkedin-be.glean.com",
 		},
+		{
+			name:  "custom full hostname",
+			input: "acmecorp-pl.glean.com",
+			want:  "acmecorp-pl.glean.com",
+		},
+		{
+			name:  "strips https scheme",
+			input: "https://acmecorp-be.glean.com",
+			want:  "acmecorp-be.glean.com",
+		},
+		{
+			name:  "strips http scheme",
+			input: "http://acmecorp-be.glean.com",
+			want:  "acmecorp-be.glean.com",
+		},
+		{
+			name:  "strips trailing slash",
+			input: "acmecorp-be.glean.com/",
+			want:  "acmecorp-be.glean.com",
+		},
+		{
+			name:  "strips scheme and trailing slash",
+			input: "https://acmecorp-be.glean.com/",
+			want:  "acmecorp-be.glean.com",
+		},
+		{
+			name:  "strips scheme from short name and expands",
+			input: "https://acmecorp",
+			want:  "acmecorp-be.glean.com",
+		},
+		{
+			name:  "localhost unchanged",
+			input: "localhost",
+			want:  "localhost",
+		},
+		{
+			name:  "localhost with port unchanged",
+			input: "localhost:8080",
+			want:  "localhost:8080",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -399,6 +399,16 @@ func TestLoadConfig_EnvHostWithFileToken(t *testing.T) {
 	assert.Equal(t, "file-token", result.GleanToken, "token from file must be used even when host comes from env")
 }
 
+func TestLoadConfig_EnvHostNormalized(t *testing.T) {
+	isolateAuthState(t)
+
+	t.Setenv("GLEAN_HOST", "linkedin")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost, "short name from env should be expanded")
+}
+
 func TestSaveHostToFile_DoesNotTouchKeyring(t *testing.T) {
 	mock, cleanupKeyring := setupTestKeyring(t)
 	_, cleanupConfig := setupTestConfig(t)


### PR DESCRIPTION
## Summary

- Fixes a bug where `GLEAN_HOST` values that are full hostnames but
  don't follow the `<instance>-be.glean.com` pattern (e.g.
  `acmecorp-pl.glean.com`) had their hostname truncated and
  `-be.glean.com` appended, producing the wrong backend URL and causing
  401 errors after a successful OAuth login
- Removes `extractInstance()` and routes all URL construction through
  `config.NormalizeHost()`, which correctly handles short names, full
  hostnames, custom deployments, user-pasted URLs with schemes, and
  localhost
- Eliminates duplicate inline expansion logic in `ValidateToken()` and
  `apiBaseURL()` that had the same bug
- Fixes a second bug where `GLEAN_HOST` set as an env var short name
  (e.g. `linkedin`) was not normalized before use, causing OAuth token
  lookups in `ResolveToken`, `Status`, `Logout`, and `EnsureAuth` to
  silently miss tokens stored under the normalized key

Closes #102

## Test plan

- [ ] `go test ./...` passes
- [ ] `go build -o glean .` succeeds
- [ ] Manual: set `GLEAN_HOST` to a non-`-be` full hostname, run
      `glean auth login` → `glean auth status` → `glean search "test"`,
      confirm all three hit the correct host
- [ ] Manual: run `glean auth login`, then set `GLEAN_HOST=<short-name>`
      as an env var and confirm `glean auth status` still shows
      authenticated