### PR TITLE
feat: migrate GLEAN_HOST to GLEAN_SERVER_URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,7 @@ body:
 
         Or with curl:
         ```bash
-        curl -s -X POST "https://$GLEAN_HOST/rest/api/v1/search" \
+        curl -s -X POST "$GLEAN_SERVER_URL/rest/api/v1/search" \
           -H "Authorization: Bearer $GLEAN_API_TOKEN" \
           -H "Content-Type: application/json" \
           -d '{"query":"test","pageSize":3}'
@@ -77,7 +77,7 @@ body:
       label: Authentication method
       options:
         - OAuth (`glean auth login`)
-        - Environment variables (`GLEAN_API_TOKEN` + `GLEAN_HOST`)
+        - Environment variables (`GLEAN_API_TOKEN` + `GLEAN_SERVER_URL`)
         - Config file (`~/.glean/config.json`)
     validations:
       required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Pushing code that breaks CI is unacceptable. No exceptions.
 mise run build          # build glean binary
 mise run test           # run tests
 mise run test:all       # lint + test + build (CI equivalent)
-./glean                 # run TUI (requires valid GLEAN_HOST + token)
+./glean                 # run TUI (requires valid GLEAN_SERVER_URL + token)
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Pre-built binaries for macOS, Linux, and Windows are available on the [Releases]
 # 1. Authenticate
 glean auth login                          # OAuth via browser (recommended)
 # — OR set env vars for CI/CD:
-# export GLEAN_HOST=your-company-be.glean.com GLEAN_API_TOKEN=your-token
+# export GLEAN_SERVER_URL=https://your-server-url GLEAN_API_TOKEN=your-token
 
 # 2. Search
 glean search "vacation policy"
@@ -117,7 +117,7 @@ For non-interactive environments, set credentials via environment variables:
 
 ```bash snippet=readme/snippet-05.sh
 export GLEAN_API_TOKEN=your-token
-export GLEAN_HOST=your-company-be.glean.com
+export GLEAN_SERVER_URL=https://your-server-url
 glean search "test"
 ```
 
@@ -317,8 +317,8 @@ glean search "all docs" --output ndjson --page-size 50 | jq .title
 
 | Variable          | Description                                               |
 | ----------------- | --------------------------------------------------------- |
-| `GLEAN_API_TOKEN` | API token — overrides keyring and config file             |
-| `GLEAN_HOST`      | Glean backend hostname (e.g. `your-company-be.glean.com`) |
+| `GLEAN_API_TOKEN`  | API token — overrides keyring and config file             |
+| `GLEAN_SERVER_URL` | Full Glean server URL. See [developers.glean.com](https://developers.glean.com/get-started/authentication) for how to find yours. |
 
 Environment variables take precedence over stored configuration.
 

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -150,22 +150,12 @@ func NewCmdAPI() *cobra.Command {
 	return cmd
 }
 
-// apiBaseURL builds the base API URL from config.
-func apiBaseURL(cfg *config.Config) string {
-	host := cfg.GleanHost
-	// Expand short names (e.g., "linkedin" → "linkedin-be.glean.com")
-	if host != "" && !strings.Contains(host, ".") {
-		host += "-be.glean.com"
-	}
-	return fmt.Sprintf("https://%s", host)
-}
-
 // apiFullURL returns the full REST API URL for an endpoint path.
 func apiFullURL(cfg *config.Config, path string) string {
 	if !strings.HasPrefix(path, "/rest/api/v1/") {
 		path = "/rest/api/v1/" + strings.TrimPrefix(path, "/")
 	}
-	return strings.TrimRight(apiBaseURL(cfg), "/") + path
+	return cfg.GleanServerURL + path
 }
 
 // rawAPIRequest makes an authenticated HTTP request to the Glean API.

--- a/cmd/api_test.go
+++ b/cmd/api_test.go
@@ -45,7 +45,7 @@ func TestAPICommand_Preview_WritesToCmdOut(t *testing.T) {
 func TestAPICommandPreviewShowsAuthHeader(t *testing.T) {
 	// Inject a test token via the env var that config.LoadConfig actually reads.
 	t.Setenv("GLEAN_API_TOKEN", "test-token-for-preview")
-	t.Setenv("GLEAN_HOST", "test.glean.com")
+	t.Setenv("GLEAN_SERVER_URL", "https://test.glean.com")
 
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAPI()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -90,14 +90,14 @@ func NewCmdRoot() *cobra.Command {
 			// Resolve identity: "email · host" or just host.
 			// Email comes from stored token or decoded from the JWT access token
 			// (Glean's RFC 8414 access tokens are JWTs containing the email claim).
-			identity := cfg.GleanHost
-			if tok, err := auth.LoadTokens(cfg.GleanHost); err == nil && tok != nil {
+			identity := cfg.GleanServerURL
+			if tok, err := auth.LoadTokens(cfg.GleanServerURL); err == nil && tok != nil {
 				email := tok.Email
 				if email == "" {
 					email = auth.EmailFromJWT(tok.AccessToken)
 				}
 				if email != "" {
-					identity = email + "  ·  " + cfg.GleanHost
+					identity = email + "  ·  " + cfg.GleanServerURL
 				}
 			}
 
@@ -183,8 +183,9 @@ func authError(err error) error {
 
 	suggestion := "Run:  glean auth login\n\n" +
 		"Or set environment variables:\n" +
-		"  export GLEAN_HOST=your-company-be.glean.com\n" +
-		"  export GLEAN_API_TOKEN=your-token"
+		"  export GLEAN_SERVER_URL=<your Glean server URL>\n" +
+		"  export GLEAN_API_TOKEN=your-token\n\n" +
+		"See https://developers.glean.com/get-started/authentication for how to find your server URL."
 	if !authErrLog.Enabled() {
 		suggestion += "\n\n  Tip: re-run with -v or GLEAN_DEBUG=auth:* for details"
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -200,8 +200,11 @@ func persistLoginState(host string, tok *StoredTokens) error {
 // config/keyring credentials for the current host.
 func Logout(ctx context.Context) error {
 	cfg, err := config.LoadConfig()
-	if err != nil || cfg.GleanServerURL == "" {
-		return fmt.Errorf("no Glean host configured")
+	if err != nil {
+		return err
+	}
+	if cfg.GleanServerURL == "" {
+		return fmt.Errorf("no Glean server URL configured")
 	}
 	if err := DeleteTokens(cfg.GleanServerURL); err != nil {
 		return fmt.Errorf("removing tokens: %w", err)
@@ -223,7 +226,10 @@ type TokenValidator func(ctx context.Context, cfg *config.Config) error
 // Status prints the current authentication state.
 // validateToken is used to verify API tokens against the backend (typically client.ValidateToken).
 func Status(ctx context.Context, validateToken TokenValidator) error {
-	cfg, _ := config.LoadConfig()
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
 	if cfg == nil || cfg.GleanServerURL == "" {
 		fmt.Println("Not configured.")
 		fmt.Println("Run 'glean auth login' to authenticate.")
@@ -272,10 +278,13 @@ func Status(ctx context.Context, validateToken TokenValidator) error {
 // EnsureAuth returns nil if the client has usable credentials.
 func EnsureAuth(ctx context.Context) error {
 	cfg, err := config.LoadConfig()
-	if err == nil && cfg.GleanToken != "" {
+	if err != nil {
+		return err
+	}
+	if cfg.GleanToken != "" {
 		return nil
 	}
-	if err == nil && cfg.GleanServerURL != "" {
+	if cfg.GleanServerURL != "" {
 		tok, _ := LoadTokens(cfg.GleanServerURL)
 		if tok != nil && !tok.IsExpired() {
 			return nil
@@ -419,10 +428,9 @@ type discoveryResult struct {
 //  2. Try OIDC discovery (oidc.NewProvider) for full OIDC support
 //  3. Fall back to RFC 8414 auth server metadata when OIDC is unavailable
 //     (Glean uses RFC 8414 but does not serve /.well-known/openid-configuration)
-func discover(ctx context.Context, host string) (*discoveryResult, error) {
-	baseURL := "https://" + host
-	discoveryLog.Log("fetching protected resource metadata: %s", baseURL)
-	meta, err := fetchProtectedResource(ctx, baseURL)
+func discover(ctx context.Context, serverURL string) (*discoveryResult, error) {
+	discoveryLog.Log("fetching protected resource metadata: %s", serverURL)
+	meta, err := fetchProtectedResource(ctx, serverURL)
 	if err != nil {
 		discoveryLog.Log("protected resource metadata failed: %v", err)
 		return nil, err

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -187,7 +187,7 @@ func persistLoginState(host string, tok *StoredTokens) error {
 	if err := config.ClearTokenFromStorage(); err != nil {
 		return fmt.Errorf("clearing stale API token: %w", err)
 	}
-	if err := config.SaveHostToFile(host); err != nil {
+	if err := config.SaveServerURLToFile(host); err != nil {
 		return fmt.Errorf("saving host: %w", err)
 	}
 	if err := SaveTokens(host, tok); err != nil {
@@ -200,19 +200,19 @@ func persistLoginState(host string, tok *StoredTokens) error {
 // config/keyring credentials for the current host.
 func Logout(ctx context.Context) error {
 	cfg, err := config.LoadConfig()
-	if err != nil || cfg.GleanHost == "" {
+	if err != nil || cfg.GleanServerURL == "" {
 		return fmt.Errorf("no Glean host configured")
 	}
-	if err := DeleteTokens(cfg.GleanHost); err != nil {
+	if err := DeleteTokens(cfg.GleanServerURL); err != nil {
 		return fmt.Errorf("removing tokens: %w", err)
 	}
-	if err := DeleteClient(cfg.GleanHost); err != nil {
+	if err := DeleteClient(cfg.GleanServerURL); err != nil {
 		return fmt.Errorf("removing oauth client: %w", err)
 	}
 	if err := config.ClearConfig(); err != nil {
 		return fmt.Errorf("clearing config: %w", err)
 	}
-	fmt.Printf("✓ Logged out from Glean (%s)\n", cfg.GleanHost)
+	fmt.Printf("✓ Logged out from Glean (%s)\n", cfg.GleanServerURL)
 	return nil
 }
 
@@ -224,7 +224,7 @@ type TokenValidator func(ctx context.Context, cfg *config.Config) error
 // validateToken is used to verify API tokens against the backend (typically client.ValidateToken).
 func Status(ctx context.Context, validateToken TokenValidator) error {
 	cfg, _ := config.LoadConfig()
-	if cfg == nil || cfg.GleanHost == "" {
+	if cfg == nil || cfg.GleanServerURL == "" {
 		fmt.Println("Not configured.")
 		fmt.Println("Run 'glean auth login' to authenticate.")
 		return nil
@@ -233,15 +233,15 @@ func Status(ctx context.Context, validateToken TokenValidator) error {
 	if cfg.GleanToken != "" {
 		masked := config.MaskToken(cfg.GleanToken)
 		if err := validateToken(ctx, cfg); err != nil {
-			fmt.Printf("✗ API token is invalid or expired\n  Host:  %s\n  Token: %s\n  Error: %v\n", cfg.GleanHost, masked, err)
+			fmt.Printf("✗ API token is invalid or expired\n  Server URL: %s\n  Token:      %s\n  Error:      %v\n", cfg.GleanServerURL, masked, err)
 			fmt.Println("Run 'glean auth login' to re-authenticate.")
 			return nil
 		}
-		fmt.Printf("✓ Authenticated via API token\n  Host:  %s\n  Token: %s\n", cfg.GleanHost, masked)
+		fmt.Printf("✓ Authenticated via API token\n  Server URL: %s\n  Token:      %s\n", cfg.GleanServerURL, masked)
 		return nil
 	}
 
-	tok, err := LoadTokens(cfg.GleanHost)
+	tok, err := LoadTokens(cfg.GleanServerURL)
 	if err != nil {
 		return fmt.Errorf("reading stored tokens: %w", err)
 	}
@@ -262,9 +262,9 @@ func Status(ctx context.Context, validateToken TokenValidator) error {
 		expStr = fmt.Sprintf("expires %s (in %v)", tok.Expiry.UTC().Format(time.RFC3339), remaining)
 	}
 	if tok.Email != "" {
-		fmt.Printf("✓ Authenticated as %s (%s)\n  Token %s\n", tok.Email, cfg.GleanHost, expStr)
+		fmt.Printf("✓ Authenticated as %s (%s)\n  Token %s\n", tok.Email, cfg.GleanServerURL, expStr)
 	} else {
-		fmt.Printf("✓ Authenticated with Glean (%s)\n  Token %s\n", cfg.GleanHost, expStr)
+		fmt.Printf("✓ Authenticated with Glean (%s)\n  Token %s\n", cfg.GleanServerURL, expStr)
 	}
 	return nil
 }
@@ -275,8 +275,8 @@ func EnsureAuth(ctx context.Context) error {
 	if err == nil && cfg.GleanToken != "" {
 		return nil
 	}
-	if err == nil && cfg.GleanHost != "" {
-		tok, _ := LoadTokens(cfg.GleanHost)
+	if err == nil && cfg.GleanServerURL != "" {
+		tok, _ := LoadTokens(cfg.GleanServerURL)
 		if tok != nil && !tok.IsExpired() {
 			return nil
 		}
@@ -366,17 +366,16 @@ func refreshOAuthToken(host string, tok *StoredTokens) (*StoredTokens, error) {
 	return stored, nil
 }
 
-// resolveHost returns the configured Glean host, prompting for email if needed.
-// The returned host is always normalized (e.g. "linkedin" → "linkedin-be.glean.com")
-// so that all downstream callers (token storage, config persistence) use a consistent value.
+// resolveHost returns the configured Glean server URL, prompting for email if needed.
+// The returned value is always normalized (full URL with scheme, no trailing slash)
+// so all downstream callers (token storage, config persistence) use a consistent value.
 func resolveHost(ctx context.Context) (string, error) {
 	cfg, _ := config.LoadConfig()
-	if cfg != nil && cfg.GleanHost != "" {
-		host := config.NormalizeHost(cfg.GleanHost)
-		hostLog.Log("using configured host: %s", host)
-		return host, nil
+	if cfg != nil && cfg.GleanServerURL != "" {
+		hostLog.Log("using configured server URL: %s", cfg.GleanServerURL)
+		return cfg.GleanServerURL, nil
 	}
-	hostLog.Log("no host configured, prompting for email")
+	hostLog.Log("no server URL configured, prompting for email")
 
 	fmt.Print("Enter your work email: ")
 	reader := bufio.NewReader(os.Stdin)
@@ -395,15 +394,13 @@ func resolveHost(ctx context.Context) (string, error) {
 	}
 	fmt.Println(" found.")
 
-	host := strings.TrimPrefix(backendURL, "https://")
-	host = strings.TrimPrefix(host, "http://")
-	host = strings.SplitN(host, "/", 2)[0]
-	hostLog.Log("discovered host: %s", host)
+	serverURL := config.NormalizeServerURL(backendURL)
+	hostLog.Log("discovered server URL: %s", serverURL)
 
-	if err := config.SaveHostToFile(host); err != nil {
-		hostLog.Log("best-effort host save failed: %v", err)
+	if err := config.SaveServerURLToFile(serverURL); err != nil {
+		hostLog.Log("best-effort server URL save failed: %v", err)
 	}
-	return host, nil
+	return serverURL, nil
 }
 
 // discoveryResult holds all OAuth metadata discovered for a Glean backend.

--- a/internal/auth/auth_fallback_test.go
+++ b/internal/auth/auth_fallback_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestDcrOrStaticClient_NoClientAvailable(t *testing.T) {
-	t.Setenv("GLEAN_HOST", "")
+	t.Setenv("GLEAN_SERVER_URL", "")
 	config.ConfigPath = t.TempDir() + "/config.json"
 
 	_, _, err := dcrOrStaticClient(context.Background(), "test-host", "", "http://127.0.0.1:9999/callback")
@@ -24,7 +24,7 @@ func TestDcrOrStaticClient_NoClientAvailable(t *testing.T) {
 }
 
 func TestDcrOrStaticClient_DCRFails_NoStaticClient(t *testing.T) {
-	t.Setenv("GLEAN_HOST", "")
+	t.Setenv("GLEAN_SERVER_URL", "")
 	config.ConfigPath = t.TempDir() + "/config.json"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -42,10 +42,10 @@ func TestDcrOrStaticClient_DCRFails_NoStaticClient(t *testing.T) {
 func TestDcrOrStaticClient_DCRFails_StaticClientFallback(t *testing.T) {
 	dir := t.TempDir()
 	config.ConfigPath = dir + "/config.json"
-	t.Setenv("GLEAN_HOST", "test-host")
+	t.Setenv("GLEAN_SERVER_URL", "test-host")
 
 	cfgData, _ := json.Marshal(map[string]string{
-		"host":                "test-host",
+		"server_url":          "test-host",
 		"oauth_client_id":     "static-id",
 		"oauth_client_secret": "static-secret",
 	})

--- a/internal/auth/auth_persistence_test.go
+++ b/internal/auth/auth_persistence_test.go
@@ -68,7 +68,7 @@ func TestOAuthTokenResolvesWhenServerURLIsPersisted(t *testing.T) {
 // TestTokensResolveAcrossSchemeForms confirms the canonical-host-key
 // guarantee end-to-end at the auth layer: a token saved under a bare hostname
 // is loadable when the persisted config later hands us a full URL. This is
-// the behaviour that lets existing OAuth sessions survive the migration to
+// the behavior that lets existing OAuth sessions survive the migration to
 // GLEAN_SERVER_URL without forcing a re-login.
 func TestTokensResolveAcrossSchemeForms(t *testing.T) {
 	authtest.IsolateAuthState(t)

--- a/internal/auth/auth_persistence_test.go
+++ b/internal/auth/auth_persistence_test.go
@@ -24,13 +24,13 @@ func oauthToken() *auth.StoredTokens {
 	}
 }
 
-func TestOAuthLoginStateRequiresPersistedHostAfterEnvHostIsRemoved(t *testing.T) {
+func TestOAuthLoginStateRequiresPersistedServerURLAfterEnvIsRemoved(t *testing.T) {
 	authtest.IsolateAuthState(t)
 
-	const host = "acme-be.glean.com"
-	require.NoError(t, auth.SaveTokens(host, oauthToken()))
+	const serverURL = "https://acme-be.glean.com"
+	require.NoError(t, auth.SaveTokens(serverURL, oauthToken()))
 
-	t.Setenv("GLEAN_HOST", host)
+	t.Setenv("GLEAN_SERVER_URL", serverURL)
 	cfg, err := config.LoadConfig()
 	require.NoError(t, err)
 
@@ -38,63 +38,62 @@ func TestOAuthLoginStateRequiresPersistedHostAfterEnvHostIsRemoved(t *testing.T)
 	assert.Equal(t, "oauth-access-token", token)
 	assert.Equal(t, "OAUTH", authType)
 
-	// Simulate a fresh shell/session after login where GLEAN_HOST is no longer set.
-	t.Setenv("GLEAN_HOST", "")
+	// Simulate a fresh shell/session after login where GLEAN_SERVER_URL is no longer set.
+	t.Setenv("GLEAN_SERVER_URL", "")
 	cfg, err = config.LoadConfig()
 	require.NoError(t, err)
-	assert.Empty(t, cfg.GleanHost, "host was never persisted by login")
+	assert.Empty(t, cfg.GleanServerURL, "server URL was never persisted by login")
 
 	token, authType = gleanClient.ResolveToken(cfg)
 	assert.Empty(t, token)
 	assert.Empty(t, authType)
 }
 
-func TestOAuthTokenResolvesWhenHostIsPersisted(t *testing.T) {
+func TestOAuthTokenResolvesWhenServerURLIsPersisted(t *testing.T) {
 	authtest.IsolateAuthState(t)
 
-	const host = "acme-be.glean.com"
-	require.NoError(t, config.SaveHostToFile(host))
-	require.NoError(t, auth.SaveTokens(host, oauthToken()))
+	const serverURL = "https://acme-be.glean.com"
+	require.NoError(t, config.SaveServerURLToFile(serverURL))
+	require.NoError(t, auth.SaveTokens(serverURL, oauthToken()))
 
 	cfg, err := config.LoadConfig()
 	require.NoError(t, err)
-	require.Equal(t, host, cfg.GleanHost)
+	require.Equal(t, serverURL, cfg.GleanServerURL)
 
 	token, authType := gleanClient.ResolveToken(cfg)
 	assert.Equal(t, "oauth-access-token", token)
 	assert.Equal(t, "OAUTH", authType)
 }
 
-func TestShortFormHostNormalizesConsistently(t *testing.T) {
+// TestTokensResolveAcrossSchemeForms confirms the canonical-host-key
+// guarantee end-to-end at the auth layer: a token saved under a bare hostname
+// is loadable when the persisted config later hands us a full URL. This is
+// the behaviour that lets existing OAuth sessions survive the migration to
+// GLEAN_SERVER_URL without forcing a re-login.
+func TestTokensResolveAcrossSchemeForms(t *testing.T) {
 	authtest.IsolateAuthState(t)
 
-	const shortHost = "acme"
-	const normalizedHost = "acme-be.glean.com"
+	// Tokens saved under the legacy bare-hostname shape.
+	require.NoError(t, auth.SaveTokens("acme-be.glean.com", oauthToken()))
 
-	// Simulate: GLEAN_HOST=acme (short form) was set during login.
-	// persistLoginState normalizes the host in the config file,
-	// and SaveTokens must use the same normalized value.
-	require.NoError(t, config.SaveHostToFile(shortHost))
-	require.NoError(t, auth.SaveTokens(config.NormalizeHost(shortHost), oauthToken()))
+	// Config has moved to the new full-URL shape.
+	require.NoError(t, config.SaveServerURLToFile("https://acme-be.glean.com"))
 
-	// Simulate next session: no env var, host loaded from config file.
 	cfg, err := config.LoadConfig()
 	require.NoError(t, err)
-	require.Equal(t, normalizedHost, cfg.GleanHost, "config file should contain normalized host")
 
-	// Token lookup must use the same normalized host.
 	token, authType := gleanClient.ResolveToken(cfg)
-	assert.Equal(t, "oauth-access-token", token, "tokens should be found via normalized host")
+	assert.Equal(t, "oauth-access-token", token, "tokens must be discoverable under the new server URL shape")
 	assert.Equal(t, "OAUTH", authType)
 }
 
 func TestStaleAPITokenClearedOnOAuthLogin(t *testing.T) {
 	authtest.IsolateAuthState(t)
 
-	const host = "acme-be.glean.com"
+	const serverURL = "https://acme-be.glean.com"
 
 	// Simulate a stale API token in config.
-	require.NoError(t, config.SaveConfig(host, "stale-api-token"))
+	require.NoError(t, config.SaveConfig(serverURL, "stale-api-token"))
 
 	cfg, err := config.LoadConfig()
 	require.NoError(t, err)
@@ -104,14 +103,14 @@ func TestStaleAPITokenClearedOnOAuthLogin(t *testing.T) {
 	// We can't call Login() directly since it requires a browser, but
 	// persistLoginState is the function that should clear stale tokens.
 	require.NoError(t, config.ClearTokenFromStorage())
-	require.NoError(t, config.SaveHostToFile(host))
-	require.NoError(t, auth.SaveTokens(host, oauthToken()))
+	require.NoError(t, config.SaveServerURLToFile(serverURL))
+	require.NoError(t, auth.SaveTokens(serverURL, oauthToken()))
 
 	// After OAuth login, the stale API token should be gone.
 	cfg, err = config.LoadConfig()
 	require.NoError(t, err)
 	assert.Empty(t, cfg.GleanToken, "stale API token should be cleared after OAuth login")
-	assert.Equal(t, host, cfg.GleanHost, "host should remain")
+	assert.Equal(t, serverURL, cfg.GleanServerURL, "server URL should remain")
 
 	// OAuth token should now be resolvable.
 	token, authType := gleanClient.ResolveToken(cfg)
@@ -119,26 +118,26 @@ func TestStaleAPITokenClearedOnOAuthLogin(t *testing.T) {
 	assert.Equal(t, "OAUTH", authType)
 }
 
-func TestLogoutClearsPersistedHostAndOAuthTokens(t *testing.T) {
+func TestLogoutClearsPersistedServerURLAndOAuthTokens(t *testing.T) {
 	authtest.IsolateAuthState(t)
 
-	const host = "acme-be.glean.com"
-	require.NoError(t, config.SaveHostToFile(host))
-	require.NoError(t, auth.SaveTokens(host, oauthToken()))
-	require.NoError(t, auth.SaveClient(host, &auth.StoredClient{ClientID: "cid-123"}))
+	const serverURL = "https://acme-be.glean.com"
+	require.NoError(t, config.SaveServerURLToFile(serverURL))
+	require.NoError(t, auth.SaveTokens(serverURL, oauthToken()))
+	require.NoError(t, auth.SaveClient(serverURL, &auth.StoredClient{ClientID: "cid-123"}))
 
 	require.NoError(t, auth.Logout(context.Background()))
 
 	cfg, err := config.LoadConfig()
 	require.NoError(t, err)
-	assert.Empty(t, cfg.GleanHost)
+	assert.Empty(t, cfg.GleanServerURL)
 	assert.Empty(t, cfg.GleanToken)
 
-	tok, err := auth.LoadTokens(host)
+	tok, err := auth.LoadTokens(serverURL)
 	require.NoError(t, err)
 	assert.Nil(t, tok)
 
-	cl, err := auth.LoadClient(host)
+	cl, err := auth.LoadClient(serverURL)
 	require.NoError(t, err)
 	assert.Nil(t, cl)
 }

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gleanwork/glean-cli/internal/fileutil"
@@ -35,9 +36,31 @@ type StoredClient struct {
 	ClientSecret string `json:"client_secret,omitempty"`
 }
 
+// canonicalHostKey reduces a server URL or bare hostname to the canonical
+// form used for keying per-host state directories (OAuth tokens, clients).
+//
+// Accepts any of:
+//
+//	"acme-be.glean.com"
+//	"https://acme-be.glean.com"
+//	"https://acme-be.glean.com/"
+//	"HTTPS://Acme-Be.Glean.Com"
+//
+// All collapse to "acme-be.glean.com", so state saved under any one input is
+// discoverable from any of the others. This preserves existing OAuth tokens
+// across the GLEAN_HOST → GLEAN_SERVER_URL migration.
+func canonicalHostKey(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ToLower(s)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	s = strings.TrimRight(s, "/")
+	return s
+}
+
 // stateDir returns ~/.local/state/glean-cli/<hash>/ for the given host.
 func stateDir(host string) string {
-	h := sha256.Sum256([]byte(host))
+	h := sha256.Sum256([]byte(canonicalHostKey(host)))
 	key := fmt.Sprintf("%x", h[:8])
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".local", "state", "glean-cli", key)

--- a/internal/auth/storage_test.go
+++ b/internal/auth/storage_test.go
@@ -96,3 +96,67 @@ func TestStateDir_FilePermissions(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0600), fi.Mode().Perm())
 }
+
+func TestCanonicalHostKey(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bare hostname", "acme-be.glean.com", "acme-be.glean.com"},
+		{"https scheme", "https://acme-be.glean.com", "acme-be.glean.com"},
+		{"http scheme", "http://acme-be.glean.com", "acme-be.glean.com"},
+		{"trailing slash", "https://acme-be.glean.com/", "acme-be.glean.com"},
+		{"multiple trailing slashes", "https://acme-be.glean.com///", "acme-be.glean.com"},
+		{"mixed case", "HTTPS://Acme-Be.Glean.Com", "acme-be.glean.com"},
+		{"surrounding whitespace", "  https://acme-be.glean.com  ", "acme-be.glean.com"},
+		{"localhost with port", "http://localhost:8080", "localhost:8080"},
+		{"vanity URL", "https://acmecorp-pl.glean.com", "acmecorp-pl.glean.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canonicalHostKey(tt.input))
+		})
+	}
+}
+
+// TestStateDir_SameForLegacyAndNew ensures the GLEAN_HOST → GLEAN_SERVER_URL
+// migration does not invalidate existing OAuth tokens: a bare hostname, the
+// same hostname with an https scheme, and the same URL with a trailing slash
+// must all hash to the same state directory.
+func TestStateDir_SameForLegacyAndNew(t *testing.T) {
+	withTempHome(t)
+
+	bare := stateDir("acme-be.glean.com")
+	scheme := stateDir("https://acme-be.glean.com")
+	trailing := stateDir("https://acme-be.glean.com/")
+	mixedCase := stateDir("HTTPS://ACME-BE.GLEAN.COM")
+
+	assert.Equal(t, bare, scheme, "bare hostname and https URL must share a state dir")
+	assert.Equal(t, bare, trailing, "trailing slash must not change state dir")
+	assert.Equal(t, bare, mixedCase, "case must not change state dir")
+}
+
+// TestStateDir_DifferentHostsDiffer ensures distinct hosts still resolve to
+// distinct directories after canonicalization.
+func TestStateDir_DifferentHostsDiffer(t *testing.T) {
+	withTempHome(t)
+
+	a := stateDir("acme-be.glean.com")
+	b := stateDir("other-be.glean.com")
+	assert.NotEqual(t, a, b)
+}
+
+// TestTokensSurviveMigrationInputChange is the end-to-end guarantee: a token
+// saved under a legacy GLEAN_HOST value is recoverable when the caller later
+// passes the same tenant as a full GLEAN_SERVER_URL.
+func TestTokensSurviveMigrationInputChange(t *testing.T) {
+	withTempHome(t)
+	tok := &StoredTokens{AccessToken: "legacy-token"}
+	require.NoError(t, SaveTokens("acme-be.glean.com", tok))
+
+	got, err := LoadTokens("https://acme-be.glean.com")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "legacy-token", got.AccessToken)
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -31,9 +31,9 @@ func ResolveToken(cfg *config.Config) (token, authType string) {
 		resolveLog.Log("using API token from env/config")
 		return cfg.GleanToken, ""
 	}
-	tok := auth.LoadOAuthToken(cfg.GleanHost)
+	tok := auth.LoadOAuthToken(cfg.GleanServerURL)
 	if tok != "" {
-		resolveLog.Log("using OAuth token for %s", cfg.GleanHost)
+		resolveLog.Log("using OAuth token for %s", cfg.GleanServerURL)
 		return tok, authTypeOAuth
 	}
 	resolveLog.Log("no credentials found")
@@ -49,8 +49,8 @@ func ValidateToken(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("no token available")
 	}
 
-	resolveLog.Log("validating token against %s", cfg.GleanHost)
-	url := "https://" + cfg.GleanHost + "/rest/api/v1/search"
+	resolveLog.Log("validating token against %s", cfg.GleanServerURL)
+	url := cfg.GleanServerURL + "/rest/api/v1/search"
 	body := strings.NewReader(`{"query":"","pageSize":1}`)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
@@ -93,12 +93,11 @@ func ValidateToken(ctx context.Context, cfg *config.Config) error {
 //  2. System keyring / ~/.glean/config.json (via config.LoadConfig)
 //  3. OAuth token from local storage (via auth.LoadOAuthToken)
 //
-// The GleanHost value is accepted in two forms:
-//   - Full hostname: "linkedin-be.glean.com" → instance = "linkedin"
-//   - Short name:   "linkedin"              → passed as-is to WithInstance
+// GleanServerURL is expected to be a fully-qualified URL (e.g.
+// "https://acme-be.glean.com"), already normalized by config.NormalizeServerURL.
 func New(cfg *config.Config) (*glean.Glean, error) {
-	if cfg.GleanHost == "" {
-		return nil, fmt.Errorf("glean host not configured. Run 'glean auth login' or set GLEAN_HOST")
+	if cfg.GleanServerURL == "" {
+		return nil, fmt.Errorf("glean server URL not configured. Run 'glean auth login' or set GLEAN_SERVER_URL")
 	}
 
 	token, authType := ResolveToken(cfg)
@@ -106,11 +105,10 @@ func New(cfg *config.Config) (*glean.Glean, error) {
 		return nil, fmt.Errorf("not authenticated — run 'glean auth login' or set GLEAN_API_TOKEN")
 	}
 
-	instance := extractInstance(cfg.GleanHost)
-	resolveLog.Log("instance=%s authType=%s", instance, authType)
+	resolveLog.Log("server_url=%s authType=%s", cfg.GleanServerURL, authType)
 
 	opts := []glean.SDKOption{
-		glean.WithInstance(instance),
+		glean.WithServerURL(cfg.GleanServerURL),
 		glean.WithSecurity(token),
 		glean.WithClient(&http.Client{
 			Transport: httputil.NewTransport(http.DefaultTransport,
@@ -134,20 +132,4 @@ func NewFromConfig() (*glean.Glean, error) {
 		return nil, err
 	}
 	return NewFunc(cfg)
-}
-
-// extractInstance derives the Glean instance name from a host value.
-// "linkedin-be.glean.com" → "linkedin"
-// "linkedin"              → "linkedin"
-func extractInstance(host string) string {
-	if strings.HasSuffix(host, "-be.glean.com") {
-		return strings.TrimSuffix(host, "-be.glean.com")
-	}
-	if strings.Contains(host, ".") {
-		// Custom hostname — use as-is; SDK will accept a full URL via WithServerURL
-		// but WithInstance only sets the variable. Return the part before the first dot
-		// as a best-effort fallback.
-		return strings.SplitN(host, ".", 2)[0]
-	}
-	return host
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -58,7 +58,7 @@ func TestTransport_APITokenOmitsHeader(t *testing.T) {
 }
 
 func TestResolveToken_APIToken(t *testing.T) {
-	cfg := &config.Config{GleanHost: "test-be.glean.com", GleanToken: "api-token-123"}
+	cfg := &config.Config{GleanServerURL: "https://test-be.glean.com", GleanToken: "api-token-123"}
 	token, authType := ResolveToken(cfg)
 	assert.Equal(t, "api-token-123", token)
 	assert.Empty(t, authType)
@@ -66,65 +66,65 @@ func TestResolveToken_APIToken(t *testing.T) {
 
 func TestResolveToken_NoToken(t *testing.T) {
 	// auth.LoadOAuthToken returns "" for an unrecognized host, so token stays empty.
-	cfg := &config.Config{GleanHost: "nonexistent-be.glean.com", GleanToken: ""}
+	cfg := &config.Config{GleanServerURL: "https://nonexistent-be.glean.com", GleanToken: ""}
 	token, authType := ResolveToken(cfg)
 	assert.Empty(t, token)
 	assert.Empty(t, authType)
 }
 
-func TestExtractInstance(t *testing.T) {
-	tests := []struct {
-		host     string
-		expected string
-	}{
-		{"linkedin-be.glean.com", "linkedin"},
-		{"linkedin", "linkedin"},
-		{"custom.example.com", "custom"},
-		{"acme-corp-be.glean.com", "acme-corp"},
-		{"single", "single"},
-		{"deep.sub.domain.example.com", "deep"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.host, func(t *testing.T) {
-			got := extractInstance(tt.host)
-			assert.Equal(t, tt.expected, got)
-		})
-	}
-}
-
 func TestValidateToken_NoToken(t *testing.T) {
-	cfg := &config.Config{GleanHost: "test-be.glean.com", GleanToken: ""}
+	cfg := &config.Config{GleanServerURL: "https://test-be.glean.com", GleanToken: ""}
 	err := ValidateToken(context.Background(), cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no token available")
 }
 
 func TestValidateToken_Unreachable(t *testing.T) {
-	cfg := &config.Config{GleanHost: "localhost:1", GleanToken: "some-token"}
+	cfg := &config.Config{GleanServerURL: "http://localhost:1", GleanToken: "some-token"}
 	err := ValidateToken(context.Background(), cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "validating token")
 }
 
-func TestNew_EmptyHost(t *testing.T) {
-	cfg := &config.Config{GleanHost: "", GleanToken: "some-token"}
+func TestNew_EmptyServerURL(t *testing.T) {
+	cfg := &config.Config{GleanServerURL: "", GleanToken: "some-token"}
 	_, err := New(cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "host not configured")
+	assert.Contains(t, err.Error(), "server URL not configured")
 }
 
 func TestNew_EmptyToken(t *testing.T) {
-	// auth.LoadOAuthToken will return "" for a fake host, so token stays empty
-	cfg := &config.Config{GleanHost: "test-be.glean.com", GleanToken: ""}
+	// auth.LoadOAuthToken will return "" for a fake URL, so token stays empty
+	cfg := &config.Config{GleanServerURL: "https://test-be.glean.com", GleanToken: ""}
 	_, err := New(cfg)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not authenticated")
 }
 
 func TestNew_Success(t *testing.T) {
-	cfg := &config.Config{GleanHost: "test-be.glean.com", GleanToken: "valid-token"}
+	cfg := &config.Config{GleanServerURL: "https://test-be.glean.com", GleanToken: "valid-token"}
 	client, err := New(cfg)
 	require.NoError(t, err)
 	assert.NotNil(t, client)
+}
+
+// TestNew_FullHostnames verifies that custom-shape Glean server URLs (vanity
+// domains, non-"-be" suffixes, obfuscated subdomains) all produce a working
+// SDK client. Covers the bugs originally reported in #102.
+func TestNew_FullHostnames(t *testing.T) {
+	urls := []string{
+		"https://acmecorp-be.glean.com",
+		"https://acmecorp-pl.glean.com",
+		"https://sub.domain.acmecorp-be.glean.com",
+		"https://search.acmecorp.com",
+		"https://a7c3d91b-be.glean.com",
+	}
+	for _, u := range urls {
+		t.Run(u, func(t *testing.T) {
+			cfg := &config.Config{GleanServerURL: u, GleanToken: "valid-token"}
+			client, err := New(cfg)
+			require.NoError(t, err)
+			assert.NotNil(t, client)
+		})
+	}
 }

--- a/internal/client/stream.go
+++ b/internal/client/stream.go
@@ -31,17 +31,15 @@ const streamTimeout = 10 * time.Minute
 // Only messages with messageType == "CONTENT" carry user-facing text; callers
 // should skip UPDATE, CONTROL, DEBUG, etc.
 func StreamChat(ctx context.Context, cfg *config.Config, req components.ChatRequest) (io.ReadCloser, error) {
-	host := cfg.GleanHost
-	if host == "" {
-		return nil, fmt.Errorf("glean host not configured")
+	serverURL := cfg.GleanServerURL
+	if serverURL == "" {
+		return nil, fmt.Errorf("glean server URL not configured")
 	}
 
 	token, authType := ResolveToken(cfg)
 	if token == "" {
 		return nil, fmt.Errorf("not authenticated — run 'glean auth login'")
 	}
-
-	host = config.NormalizeHost(host)
 
 	stream := true
 	req.Stream = &stream
@@ -61,7 +59,7 @@ func StreamChat(ctx context.Context, cfg *config.Config, req components.ChatRequ
 		return nil, fmt.Errorf("marshaling chat request: %w", err)
 	}
 
-	url := fmt.Sprintf("https://%s/rest/api/v1/chat", host)
+	url := serverURL + "/rest/api/v1/chat"
 	streamLog.Log("POST %s (%d bytes)", url, len(payload))
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,11 +82,29 @@ func NormalizeServerURL(s string) string {
 	return s
 }
 
+// legacyHostEnvError is returned when the caller has the retired GLEAN_HOST
+// environment variable set without a matching GLEAN_SERVER_URL. It surfaces
+// the rename in a single message rather than letting the user hit a generic
+// "not configured" error downstream.
+const legacyHostEnvError = `the GLEAN_HOST environment variable is no longer supported. Use GLEAN_SERVER_URL instead.
+
+  export GLEAN_SERVER_URL=<your Glean server URL>
+
+See https://developers.glean.com/get-started/authentication for how to find your server URL.`
+
 // LoadConfig retrieves configuration using the following priority order:
 //  1. Environment variables (GLEAN_API_TOKEN, GLEAN_SERVER_URL)
 //  2. System keyring
 //  3. ~/.glean/config.json
+//
+// If GLEAN_HOST is set without GLEAN_SERVER_URL, LoadConfig returns an error
+// describing the rename rather than falling through to a "not configured"
+// message from a downstream caller.
 func LoadConfig() (*Config, error) {
+	if os.Getenv("GLEAN_SERVER_URL") == "" && os.Getenv("GLEAN_HOST") != "" {
+		return nil, fmt.Errorf("%s", legacyHostEnvError)
+	}
+
 	cfg := loadFromEnv()
 	cfgLog.Log("env: server_url=%t token=%t", cfg.GleanServerURL != "", cfg.GleanToken != "")
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,33 @@ func NormalizeHost(host string) string {
 	return host
 }
 
+// NormalizeServerURL canonicalizes a Glean server URL value.
+// It trims surrounding whitespace, strips trailing slashes, and ensures a
+// scheme is present (defaulting to https). Existing schemes are preserved,
+// so "http://localhost:8080" stays on http.
+//
+// The function is idempotent — applying it twice yields the same result as
+// applying it once.
+//
+// Examples:
+//
+//	NormalizeServerURL("acme-be.glean.com")          → "https://acme-be.glean.com"
+//	NormalizeServerURL("https://acme-be.glean.com")  → "https://acme-be.glean.com"
+//	NormalizeServerURL("https://acme-be.glean.com/") → "https://acme-be.glean.com"
+//	NormalizeServerURL("http://localhost:8080")      → "http://localhost:8080"
+//	NormalizeServerURL("")                           → ""
+func NormalizeServerURL(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.TrimRight(s, "/")
+	if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		s = "https://" + s
+	}
+	return s
+}
+
 // ValidateAndTransformHost is a compatibility wrapper around NormalizeHost.
 func ValidateAndTransformHost(host string) (string, error) {
 	return NormalizeHost(host), nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -302,10 +302,24 @@ func init() {
 func loadFromKeyring() *Config {
 	cfg := &Config{}
 
-	if v, err := keyringImpl.Get(ServiceName, serverURLKey); err == nil {
+	v, err := keyringImpl.Get(ServiceName, serverURLKey)
+	if err == nil {
 		cfg.GleanServerURL = v
 	} else {
 		keyringLog.Log("get %s: %v", serverURLKey, err)
+		// Legacy migration: fall back to the pre-rename "host" key and
+		// migrate its value forward on successful read.
+		if legacy, legacyErr := keyringImpl.Get(ServiceName, "host"); legacyErr == nil && legacy != "" {
+			cfg.GleanServerURL = NormalizeServerURL(legacy)
+			keyringLog.Log("migrating legacy keyring key 'host' -> '%s' (%s)", serverURLKey, cfg.GleanServerURL)
+			if setErr := keyringImpl.Set(ServiceName, serverURLKey, cfg.GleanServerURL); setErr == nil {
+				if delErr := keyringImpl.Delete(ServiceName, "host"); delErr != nil && delErr != keyring.ErrNotFound {
+					keyringLog.Log("best-effort delete of legacy 'host' key failed: %v", delErr)
+				}
+			} else {
+				keyringLog.Log("best-effort rewrite of migrated keyring value failed: %v", setErr)
+			}
+		}
 	}
 
 	if token, err := keyringImpl.Get(ServiceName, tokenKey); err == nil {
@@ -319,6 +333,7 @@ func loadFromKeyring() *Config {
 
 var knownConfigKeys = map[string]bool{
 	"server_url":          true,
+	"host":                true, // legacy; migrated to "server_url" on load
 	"token":               true,
 	"oauth_client_id":     true,
 	"oauth_client_secret": true,
@@ -361,6 +376,25 @@ func loadFromFile() (*Config, error) {
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	// Legacy migration: if the file has the pre-rename "host" key but no
+	// "server_url", copy the value (normalized) into GleanServerURL and
+	// rewrite the file so subsequent loads see only the new shape.
+	if cfg.GleanServerURL == "" {
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(data, &raw); err == nil {
+			if legacyHostBytes, ok := raw["host"]; ok {
+				var legacyHost string
+				if err := json.Unmarshal(legacyHostBytes, &legacyHost); err == nil && legacyHost != "" {
+					cfg.GleanServerURL = NormalizeServerURL(legacyHost)
+					cfgLog.Log("migrating legacy config key 'host' -> 'server_url' (%s)", cfg.GleanServerURL)
+					if err := saveToFile(&cfg); err != nil {
+						cfgLog.Log("best-effort rewrite of migrated config failed: %v", err)
+					}
+				}
+			}
+		}
 	}
 
 	return &cfg, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,13 +34,13 @@ var ServiceName = "glean-cli"
 var ConfigPath string
 
 const (
-	hostKey  = "host"
-	tokenKey = "token"
+	serverURLKey = "server_url"
+	tokenKey     = "token"
 )
 
 // Config holds the Glean API credentials and connection settings.
 type Config struct {
-	GleanHost         string `json:"host"`
+	GleanServerURL    string `json:"server_url"`
 	GleanToken        string `json:"token"`
 	OAuthClientID     string `json:"oauth_client_id,omitempty"`
 	OAuthClientSecret string `json:"oauth_client_secret,omitempty"`
@@ -53,16 +53,6 @@ func MaskToken(token string) string {
 		return strings.Repeat("*", len(token))
 	}
 	return token[:4] + strings.Repeat("*", len(token)-8) + token[len(token)-4:]
-}
-
-// NormalizeHost ensures the Glean host is in the correct format,
-// transforming short names (e.g., "linkedin") to full hostnames (e.g., "linkedin-be.glean.com").
-// Full hostnames (containing a ".") are returned unchanged.
-func NormalizeHost(host string) string {
-	if !strings.Contains(host, ".") {
-		return host + "-be.glean.com"
-	}
-	return host
 }
 
 // NormalizeServerURL canonicalizes a Glean server URL value.
@@ -92,38 +82,33 @@ func NormalizeServerURL(s string) string {
 	return s
 }
 
-// ValidateAndTransformHost is a compatibility wrapper around NormalizeHost.
-func ValidateAndTransformHost(host string) (string, error) {
-	return NormalizeHost(host), nil
-}
-
 // LoadConfig retrieves configuration using the following priority order:
-//  1. Environment variables (GLEAN_API_TOKEN, GLEAN_HOST)
+//  1. Environment variables (GLEAN_API_TOKEN, GLEAN_SERVER_URL)
 //  2. System keyring
 //  3. ~/.glean/config.json
 func LoadConfig() (*Config, error) {
 	cfg := loadFromEnv()
-	cfgLog.Log("env: host=%t token=%t", cfg.GleanHost != "", cfg.GleanToken != "")
+	cfgLog.Log("env: server_url=%t token=%t", cfg.GleanServerURL != "", cfg.GleanToken != "")
 
-	if cfg.GleanHost == "" || cfg.GleanToken == "" {
+	if cfg.GleanServerURL == "" || cfg.GleanToken == "" {
 		keyringCfg := loadFromKeyring()
-		if cfg.GleanHost == "" {
-			cfg.GleanHost = keyringCfg.GleanHost
+		if cfg.GleanServerURL == "" {
+			cfg.GleanServerURL = keyringCfg.GleanServerURL
 		}
 		if cfg.GleanToken == "" {
 			cfg.GleanToken = keyringCfg.GleanToken
 		}
-		cfgLog.Log("after keyring: host=%t token=%t", cfg.GleanHost != "", cfg.GleanToken != "")
+		cfgLog.Log("after keyring: server_url=%t token=%t", cfg.GleanServerURL != "", cfg.GleanToken != "")
 	}
 
-	if cfg.GleanHost == "" || cfg.GleanToken == "" {
+	if cfg.GleanServerURL == "" || cfg.GleanToken == "" {
 		fileCfg, err := loadFromFile()
 		if err != nil {
 			cfgLog.Log("config file error: %v", err)
 			return nil, err
 		}
-		if cfg.GleanHost == "" {
-			cfg.GleanHost = fileCfg.GleanHost
+		if cfg.GleanServerURL == "" {
+			cfg.GleanServerURL = fileCfg.GleanServerURL
 		}
 		if cfg.GleanToken == "" {
 			cfg.GleanToken = fileCfg.GleanToken
@@ -134,39 +119,37 @@ func LoadConfig() (*Config, error) {
 		if cfg.OAuthClientSecret == "" {
 			cfg.OAuthClientSecret = fileCfg.OAuthClientSecret
 		}
-		cfgLog.Log("after file: host=%t token=%t", cfg.GleanHost != "", cfg.GleanToken != "")
+		cfgLog.Log("after file: server_url=%t token=%t", cfg.GleanServerURL != "", cfg.GleanToken != "")
 	}
 
-	cfgLog.Log("resolved host=%s token=%t", cfg.GleanHost, cfg.GleanToken != "")
+	cfgLog.Log("resolved server_url=%s token=%t", cfg.GleanServerURL, cfg.GleanToken != "")
 	return cfg, nil
 }
 
 // loadFromEnv reads config values from environment variables.
 // GLEAN_API_TOKEN takes precedence over all other credential sources.
+// GLEAN_SERVER_URL is normalized on read so downstream callers always see a
+// canonical form (scheme included, no trailing slash).
 func loadFromEnv() *Config {
 	cfg := &Config{}
 	if v := os.Getenv("GLEAN_API_TOKEN"); v != "" {
 		cfg.GleanToken = v
 	}
-	if v := os.Getenv("GLEAN_HOST"); v != "" {
-		cfg.GleanHost = v
+	if v := os.Getenv("GLEAN_SERVER_URL"); v != "" {
+		cfg.GleanServerURL = NormalizeServerURL(v)
 	}
 	return cfg
 }
 
-// SaveConfig stores host and token in both the system keyring and file storage.
-func SaveConfig(host, token string) error {
-	if host != "" {
-		validHost, err := ValidateAndTransformHost(host)
-		if err != nil {
-			return err
-		}
-		host = validHost
+// SaveConfig stores the server URL and token in both the system keyring and file storage.
+func SaveConfig(serverURL, token string) error {
+	if serverURL != "" {
+		serverURL = NormalizeServerURL(serverURL)
 	}
 
 	var keyringErr error
-	if host != "" {
-		if err := keyringImpl.Set(ServiceName, hostKey, host); err != nil {
+	if serverURL != "" {
+		if err := keyringImpl.Set(ServiceName, serverURLKey, serverURL); err != nil {
 			keyringErr = err
 		}
 	}
@@ -182,8 +165,8 @@ func SaveConfig(host, token string) error {
 		cfg = existingCfg
 	}
 
-	if host != "" {
-		cfg.GleanHost = host
+	if serverURL != "" {
+		cfg.GleanServerURL = serverURL
 	}
 	if token != "" {
 		cfg.GleanToken = token
@@ -205,16 +188,12 @@ func SaveConfig(host, token string) error {
 	}
 }
 
-// SaveHostToFile persists only the host in ~/.glean/config.json without touching
-// the system keyring. This is intended for OAuth flows where the host is not
-// secret and persisting it should not trigger OS keychain prompts.
-func SaveHostToFile(host string) error {
-	if host != "" {
-		validHost, err := ValidateAndTransformHost(host)
-		if err != nil {
-			return err
-		}
-		host = validHost
+// SaveServerURLToFile persists only the server URL in ~/.glean/config.json
+// without touching the system keyring. This is intended for OAuth flows where
+// the URL is not secret and persisting it should not trigger OS keychain prompts.
+func SaveServerURLToFile(serverURL string) error {
+	if serverURL != "" {
+		serverURL = NormalizeServerURL(serverURL)
 	}
 
 	cfg := &Config{}
@@ -222,13 +201,13 @@ func SaveHostToFile(host string) error {
 	if err == nil {
 		cfg = existingCfg
 	}
-	cfg.GleanHost = host
+	cfg.GleanServerURL = serverURL
 
 	return saveToFile(cfg)
 }
 
 // ClearTokenFromStorage removes only the API token from keyring and config file,
-// leaving the host and other settings intact. This is used during OAuth login to
+// leaving the server URL and other settings intact. This is used during OAuth login to
 // prevent a stale API token from shadowing newly obtained OAuth credentials.
 func ClearTokenFromStorage() error {
 	cfgLog.Log("clearing stale API token from storage")
@@ -255,7 +234,7 @@ func ClearTokenFromStorage() error {
 func ClearConfig() error {
 	var keyringErr error
 
-	if err := keyringImpl.Delete(ServiceName, hostKey); err != nil && err != keyring.ErrNotFound {
+	if err := keyringImpl.Delete(ServiceName, serverURLKey); err != nil && err != keyring.ErrNotFound {
 		keyringErr = err
 	}
 	if err := keyringImpl.Delete(ServiceName, tokenKey); err != nil && err != keyring.ErrNotFound {
@@ -305,10 +284,10 @@ func init() {
 func loadFromKeyring() *Config {
 	cfg := &Config{}
 
-	if host, err := keyringImpl.Get(ServiceName, hostKey); err == nil {
-		cfg.GleanHost = host
+	if v, err := keyringImpl.Get(ServiceName, serverURLKey); err == nil {
+		cfg.GleanServerURL = v
 	} else {
-		keyringLog.Log("get %s: %v", hostKey, err)
+		keyringLog.Log("get %s: %v", serverURLKey, err)
 	}
 
 	if token, err := keyringImpl.Get(ServiceName, tokenKey); err == nil {
@@ -321,7 +300,7 @@ func loadFromKeyring() *Config {
 }
 
 var knownConfigKeys = map[string]bool{
-	"host":                true,
+	"server_url":          true,
 	"token":               true,
 	"oauth_client_id":     true,
 	"oauth_client_secret": true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -471,6 +471,73 @@ func TestSaveServerURLToFile_DoesNotTouchKeyring(t *testing.T) {
 	assert.Empty(t, cfg.GleanToken)
 }
 
+// TestLoadFromFile_MigratesLegacyHostKey verifies that a config file produced
+// by the pre-rename CLI (which wrote `"host": "acme-be.glean.com"`) is read
+// correctly on first load under the new code, has its value normalized to a
+// full URL, and is rewritten so the legacy key does not linger.
+func TestLoadFromFile_MigratesLegacyHostKey(t *testing.T) {
+	isolateAuthState(t)
+
+	legacy := []byte(`{"host":"acme-be.glean.com","token":"tok"}`)
+	require.NoError(t, os.MkdirAll(filepath.Dir(ConfigPath), 0700))
+	require.NoError(t, os.WriteFile(ConfigPath, legacy, 0600))
+
+	cfg, err := loadFromFile()
+	require.NoError(t, err)
+	assert.Equal(t, "https://acme-be.glean.com", cfg.GleanServerURL, "legacy host value must migrate to normalized server URL")
+	assert.Equal(t, "tok", cfg.GleanToken)
+
+	// File on disk should now use the new key and drop the legacy one.
+	rewritten, err := os.ReadFile(ConfigPath)
+	require.NoError(t, err)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(rewritten, &raw))
+	assert.Contains(t, raw, "server_url")
+	assert.NotContains(t, raw, "host", "legacy 'host' key should be dropped after migration")
+
+	// Second load must be idempotent.
+	cfg2, err := loadFromFile()
+	require.NoError(t, err)
+	assert.Equal(t, cfg.GleanServerURL, cfg2.GleanServerURL)
+}
+
+// TestLoadFromFile_ServerURLTakesPrecedenceOverLegacyHost covers a config
+// file that has both keys (unlikely in practice, but possible from manual
+// edits during a transition). The new key wins; the legacy one is ignored.
+func TestLoadFromFile_ServerURLTakesPrecedenceOverLegacyHost(t *testing.T) {
+	isolateAuthState(t)
+
+	both := []byte(`{"server_url":"https://acme-be.glean.com","host":"ignored-be.glean.com","token":"tok"}`)
+	require.NoError(t, os.MkdirAll(filepath.Dir(ConfigPath), 0700))
+	require.NoError(t, os.WriteFile(ConfigPath, both, 0600))
+
+	cfg, err := loadFromFile()
+	require.NoError(t, err)
+	assert.Equal(t, "https://acme-be.glean.com", cfg.GleanServerURL)
+}
+
+// TestLoadFromKeyring_MigratesLegacyHostKey verifies the keyring-side
+// counterpart of the file migration: a value stored under the legacy "host"
+// key is surfaced as GleanServerURL and moved to the new "server_url" key,
+// with the legacy one removed.
+func TestLoadFromKeyring_MigratesLegacyHostKey(t *testing.T) {
+	mock, cleanup := setupTestKeyring(t)
+	defer cleanup()
+
+	require.NoError(t, mock.Set(ServiceName, "host", "acme-be.glean.com"))
+
+	cfg := loadFromKeyring()
+	assert.Equal(t, "https://acme-be.glean.com", cfg.GleanServerURL)
+
+	// New key populated, legacy key gone.
+	newVal, err := mock.Get(ServiceName, "server_url")
+	require.NoError(t, err)
+	assert.Equal(t, "https://acme-be.glean.com", newVal)
+
+	_, err = mock.Get(ServiceName, "host")
+	assert.ErrorIs(t, err, keyring.ErrNotFound, "legacy keyring 'host' key should be deleted after migration")
+}
+
 func TestValidateConfigKeys(t *testing.T) {
 	t.Run("unknown key produces warning", func(t *testing.T) {
 		data := []byte(`{"server_url":"https://x.glean.com","toke":"bad"}`)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -421,6 +421,41 @@ func TestLoadConfig_EnvHostWithFileToken(t *testing.T) {
 	assert.Equal(t, "file-token", result.GleanToken, "token from file must be used even when server URL comes from env")
 }
 
+func TestLoadConfig_LegacyHostEnv_Errors(t *testing.T) {
+	isolateAuthState(t)
+
+	t.Setenv("GLEAN_SERVER_URL", "")
+	t.Setenv("GLEAN_HOST", "acme-be.glean.com")
+
+	_, err := LoadConfig()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GLEAN_HOST environment variable is no longer supported")
+	assert.Contains(t, err.Error(), "GLEAN_SERVER_URL")
+	assert.Contains(t, err.Error(), "https://developers.glean.com/get-started/authentication")
+}
+
+func TestLoadConfig_LegacyHostEnv_IgnoredWhenNewIsSet(t *testing.T) {
+	isolateAuthState(t)
+
+	t.Setenv("GLEAN_SERVER_URL", "https://acme-be.glean.com")
+	t.Setenv("GLEAN_HOST", "ignored-be.glean.com")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, "https://acme-be.glean.com", cfg.GleanServerURL)
+}
+
+func TestLoadConfig_NeitherEnvSet_NoError(t *testing.T) {
+	isolateAuthState(t)
+
+	t.Setenv("GLEAN_SERVER_URL", "")
+	t.Setenv("GLEAN_HOST", "")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.GleanServerURL)
+}
+
 func TestSaveServerURLToFile_DoesNotTouchKeyring(t *testing.T) {
 	mock, cleanupKeyring := setupTestKeyring(t)
 	_, cleanupConfig := setupTestConfig(t)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -169,6 +169,104 @@ func TestValidateAndTransformHost(t *testing.T) {
 	}
 }
 
+func TestNormalizeServerURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "empty string returns empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "whitespace returns empty",
+			input: "   ",
+			want:  "",
+		},
+		{
+			name:  "no scheme prepends https",
+			input: "acme-be.glean.com",
+			want:  "https://acme-be.glean.com",
+		},
+		{
+			name:  "https preserved",
+			input: "https://acme-be.glean.com",
+			want:  "https://acme-be.glean.com",
+		},
+		{
+			name:  "http preserved for localhost",
+			input: "http://localhost:8080",
+			want:  "http://localhost:8080",
+		},
+		{
+			name:  "http preserved for non-localhost",
+			input: "http://acme-be.glean.com",
+			want:  "http://acme-be.glean.com",
+		},
+		{
+			name:  "trailing slash stripped",
+			input: "https://acme-be.glean.com/",
+			want:  "https://acme-be.glean.com",
+		},
+		{
+			name:  "multiple trailing slashes stripped",
+			input: "https://acme-be.glean.com///",
+			want:  "https://acme-be.glean.com",
+		},
+		{
+			name:  "vanity URL preserved",
+			input: "acmecorp-pl.glean.com",
+			want:  "https://acmecorp-pl.glean.com",
+		},
+		{
+			name:  "obfuscated URL preserved",
+			input: "a7c3d91b-be.glean.com",
+			want:  "https://a7c3d91b-be.glean.com",
+		},
+		{
+			name:  "surrounding whitespace trimmed",
+			input: "  https://acme-be.glean.com  ",
+			want:  "https://acme-be.glean.com",
+		},
+		{
+			name:  "localhost without port",
+			input: "localhost",
+			want:  "https://localhost",
+		},
+		{
+			name:  "localhost with port no scheme",
+			input: "localhost:8080",
+			want:  "https://localhost:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeServerURL(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNormalizeServerURL_Idempotent(t *testing.T) {
+	inputs := []string{
+		"acme-be.glean.com",
+		"https://acme-be.glean.com",
+		"https://acme-be.glean.com/",
+		"http://localhost:8080",
+		"acmecorp-pl.glean.com",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			once := NormalizeServerURL(in)
+			twice := NormalizeServerURL(once)
+			assert.Equal(t, once, twice, "normalizer must be idempotent")
+		})
+	}
+}
+
 func TestConfigPath(t *testing.T) {
 	t.Run("default config path", func(t *testing.T) {
 		homeDir, err := os.UserHomeDir()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -133,42 +133,6 @@ func isolateAuthState(t *testing.T) {
 	keyring.MockInit()
 }
 
-func TestValidateAndTransformHost(t *testing.T) {
-	tests := []struct {
-		name        string
-		input       string
-		want        string
-		errContains string
-		wantErr     bool
-	}{
-		{
-			name:  "simple instance name",
-			input: "linkedin",
-			want:  "linkedin-be.glean.com",
-		},
-		{
-			name:  "full valid hostname",
-			input: "linkedin-be.glean.com",
-			want:  "linkedin-be.glean.com",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ValidateAndTransformHost(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
-				if tt.errContains != "" {
-					assert.Contains(t, err.Error(), tt.errContains)
-				}
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
-			}
-		})
-	}
-}
-
 func TestNormalizeServerURL(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -285,14 +249,14 @@ func TestConfigOperations(t *testing.T) {
 
 	t.Run("save and load config with working keyring", func(t *testing.T) {
 		// Save config
-		err := SaveConfig("linkedin", "test-token")
+		err := SaveConfig("https://linkedin-be.glean.com", "test-token")
 		require.NoError(t, err)
 
 		// Load config
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
 
-		assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost)
+		assert.Equal(t, "https://linkedin-be.glean.com", cfg.GleanServerURL)
 		assert.Equal(t, "test-token", cfg.GleanToken)
 
 		// Verify config file was also created
@@ -301,7 +265,7 @@ func TestConfigOperations(t *testing.T) {
 
 	t.Run("fallback to config file when keyring fails", func(t *testing.T) {
 		// First save config successfully
-		err := SaveConfig("linkedin", "test-token")
+		err := SaveConfig("https://linkedin-be.glean.com", "test-token")
 		require.NoError(t, err)
 
 		// Now simulate keyring failure
@@ -311,13 +275,13 @@ func TestConfigOperations(t *testing.T) {
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
 
-		assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost)
+		assert.Equal(t, "https://linkedin-be.glean.com", cfg.GleanServerURL)
 		assert.Equal(t, "test-token", cfg.GleanToken)
 	})
 
 	t.Run("clear config removes from both storages", func(t *testing.T) {
 		// First save some config
-		err := SaveConfig("linkedin", "test-token")
+		err := SaveConfig("https://linkedin-be.glean.com", "test-token")
 		require.NoError(t, err)
 
 		// Reset mock error
@@ -328,7 +292,7 @@ func TestConfigOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify keyring is cleared
-		_, err = keyringImpl.Get(ServiceName, hostKey)
+		_, err = keyringImpl.Get(ServiceName, serverURLKey)
 		assert.Equal(t, keyring.ErrNotFound, err)
 
 		// Verify config file is removed
@@ -338,7 +302,7 @@ func TestConfigOperations(t *testing.T) {
 		// Load config should return empty values
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
-		assert.Empty(t, cfg.GleanHost)
+		assert.Empty(t, cfg.GleanServerURL)
 		assert.Empty(t, cfg.GleanToken)
 	})
 
@@ -365,7 +329,7 @@ func TestConfigOperations(t *testing.T) {
 			os.MkdirAll(configDir, 0700)
 		}()
 
-		err = SaveConfig("linkedin", "test-token")
+		err = SaveConfig("https://linkedin-be.glean.com", "test-token")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to save config")
 		assert.Contains(t, err.Error(), "keyring:")
@@ -379,8 +343,8 @@ func TestConfigOperations(t *testing.T) {
 func TestClearTokenFromStorage(t *testing.T) {
 	isolateAuthState(t)
 
-	t.Run("clears token but preserves host", func(t *testing.T) {
-		require.NoError(t, SaveConfig("linkedin", "stale-api-token"))
+	t.Run("clears token but preserves server URL", func(t *testing.T) {
+		require.NoError(t, SaveConfig("https://linkedin-be.glean.com", "stale-api-token"))
 
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
@@ -391,21 +355,21 @@ func TestClearTokenFromStorage(t *testing.T) {
 		cfg, err = LoadConfig()
 		require.NoError(t, err)
 		assert.Empty(t, cfg.GleanToken, "token should be cleared")
-		assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost, "host should be preserved")
+		assert.Equal(t, "https://linkedin-be.glean.com", cfg.GleanServerURL, "server URL should be preserved")
 	})
 
 	t.Run("no-op when no token exists", func(t *testing.T) {
 		// Clear state from previous subtest.
 		_ = ClearConfig()
 
-		require.NoError(t, SaveHostToFile("acme"))
+		require.NoError(t, SaveServerURLToFile("https://acme-be.glean.com"))
 
 		require.NoError(t, ClearTokenFromStorage())
 
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
 		assert.Empty(t, cfg.GleanToken)
-		assert.Equal(t, "acme-be.glean.com", cfg.GleanHost)
+		assert.Equal(t, "https://acme-be.glean.com", cfg.GleanServerURL)
 	})
 }
 
@@ -414,16 +378,16 @@ func TestLoadConfigEnvPriority(t *testing.T) {
 
 	t.Run("GLEAN_API_TOKEN overrides keyring", func(t *testing.T) {
 		t.Setenv("GLEAN_API_TOKEN", "env-token")
-		t.Setenv("GLEAN_HOST", "env-be.glean.com")
+		t.Setenv("GLEAN_SERVER_URL", "https://env-be.glean.com")
 
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
 		assert.Equal(t, "env-token", cfg.GleanToken)
-		assert.Equal(t, "env-be.glean.com", cfg.GleanHost)
+		assert.Equal(t, "https://env-be.glean.com", cfg.GleanServerURL)
 	})
 
 	t.Run("falls through to keyring when env vars absent", func(t *testing.T) {
-		require.NoError(t, SaveConfig("linkedin", "keyring-token"))
+		require.NoError(t, SaveConfig("https://linkedin-be.glean.com", "keyring-token"))
 
 		cfg, err := LoadConfig()
 		require.NoError(t, err)
@@ -434,14 +398,14 @@ func TestLoadConfigEnvPriority(t *testing.T) {
 func TestLoadConfig_EnvTokenWithKeyringHost(t *testing.T) {
 	isolateAuthState(t)
 
-	err := SaveConfig("myhost.glean.com", "")
+	err := SaveConfig("https://myhost.glean.com", "")
 	require.NoError(t, err)
 	t.Setenv("GLEAN_API_TOKEN", "env-token")
 
 	result, err := LoadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, "env-token", result.GleanToken)
-	assert.Equal(t, "myhost.glean.com", result.GleanHost, "host from keyring must be used even when token comes from env")
+	assert.Equal(t, "https://myhost.glean.com", result.GleanServerURL, "server URL from keyring must be used even when token comes from env")
 }
 
 func TestLoadConfig_EnvHostWithFileToken(t *testing.T) {
@@ -449,39 +413,39 @@ func TestLoadConfig_EnvHostWithFileToken(t *testing.T) {
 
 	err := saveToFile(&Config{GleanToken: "file-token"})
 	require.NoError(t, err)
-	t.Setenv("GLEAN_HOST", "envhost.glean.com")
+	t.Setenv("GLEAN_SERVER_URL", "https://envhost.glean.com")
 
 	result, err := LoadConfig()
 	require.NoError(t, err)
-	assert.Equal(t, "envhost.glean.com", result.GleanHost)
-	assert.Equal(t, "file-token", result.GleanToken, "token from file must be used even when host comes from env")
+	assert.Equal(t, "https://envhost.glean.com", result.GleanServerURL)
+	assert.Equal(t, "file-token", result.GleanToken, "token from file must be used even when server URL comes from env")
 }
 
-func TestSaveHostToFile_DoesNotTouchKeyring(t *testing.T) {
+func TestSaveServerURLToFile_DoesNotTouchKeyring(t *testing.T) {
 	mock, cleanupKeyring := setupTestKeyring(t)
 	_, cleanupConfig := setupTestConfig(t)
 	defer cleanupKeyring()
 	defer cleanupConfig()
 
 	mock.err = assert.AnError
-	require.NoError(t, SaveHostToFile("linkedin"))
+	require.NoError(t, SaveServerURLToFile("https://linkedin-be.glean.com"))
 
 	cfg, err := loadFromFile()
 	require.NoError(t, err)
-	assert.Equal(t, "linkedin-be.glean.com", cfg.GleanHost)
+	assert.Equal(t, "https://linkedin-be.glean.com", cfg.GleanServerURL)
 	assert.Empty(t, cfg.GleanToken)
 }
 
 func TestValidateConfigKeys(t *testing.T) {
 	t.Run("unknown key produces warning", func(t *testing.T) {
-		data := []byte(`{"host":"x.glean.com","toke":"bad"}`)
+		data := []byte(`{"server_url":"https://x.glean.com","toke":"bad"}`)
 		warnings := validateConfigKeys(data)
 		require.Len(t, warnings, 1)
 		assert.Contains(t, warnings[0], `unknown key "toke"`)
 	})
 
 	t.Run("all known keys produce no warnings", func(t *testing.T) {
-		data := []byte(`{"host":"x","token":"t","oauth_client_id":"id","oauth_client_secret":"s"}`)
+		data := []byte(`{"server_url":"https://x.glean.com","token":"t","oauth_client_id":"id","oauth_client_secret":"s"}`)
 		warnings := validateConfigKeys(data)
 		assert.Empty(t, warnings)
 	})
@@ -489,7 +453,7 @@ func TestValidateConfigKeys(t *testing.T) {
 	t.Run("unknown keys do not prevent loading", func(t *testing.T) {
 		isolateAuthState(t)
 
-		cfgData := []byte(`{"host":"test-be.glean.com","token":"tok","extra_field":"val"}`)
+		cfgData := []byte(`{"server_url":"https://test-be.glean.com","token":"tok","extra_field":"val"}`)
 		err := os.MkdirAll(filepath.Dir(ConfigPath), 0700)
 		require.NoError(t, err)
 		err = os.WriteFile(ConfigPath, cfgData, 0600)
@@ -497,7 +461,7 @@ func TestValidateConfigKeys(t *testing.T) {
 
 		cfg, err := loadFromFile()
 		require.NoError(t, err)
-		assert.Equal(t, "test-be.glean.com", cfg.GleanHost)
+		assert.Equal(t, "https://test-be.glean.com", cfg.GleanServerURL)
 		assert.Equal(t, "tok", cfg.GleanToken)
 	})
 
@@ -514,7 +478,7 @@ func TestLoadFromFile(t *testing.T) {
 	t.Run("load non-existent file returns empty config", func(t *testing.T) {
 		cfg, err := loadFromFile()
 		require.NoError(t, err)
-		assert.Empty(t, cfg.GleanHost)
+		assert.Empty(t, cfg.GleanServerURL)
 		assert.Empty(t, cfg.GleanToken)
 	})
 
@@ -529,8 +493,8 @@ func TestLoadFromFile(t *testing.T) {
 
 	t.Run("load valid config file", func(t *testing.T) {
 		cfg := Config{
-			GleanHost:  "test-be.glean.com",
-			GleanToken: "test-token",
+			GleanServerURL: "https://test-be.glean.com",
+			GleanToken:     "test-token",
 		}
 		data, err := json.MarshalIndent(cfg, "", "  ")
 		require.NoError(t, err)

--- a/internal/skills/generator.go
+++ b/internal/skills/generator.go
@@ -204,7 +204,7 @@ glean auth status
 
 # CI/scripting (no interactive setup needed)
 export GLEAN_API_TOKEN=your-token
-export GLEAN_HOST=your-company-be.glean.com
+export GLEAN_SERVER_URL=<your Glean server URL>
 ` + "```" + `
 
 Credentials resolve in this order: environment variables → system keyring → ~/.glean/config.json.

--- a/internal/testutils/mock_client.go
+++ b/internal/testutils/mock_client.go
@@ -61,7 +61,7 @@ func SetupMockClient(body []byte, err error) (*MockTransport, func()) {
 	origFunc := client.NewFunc
 	client.NewFunc = func(cfg *config.Config) (*glean.Glean, error) {
 		return glean.New(
-			glean.WithInstance("test-company"),
+			glean.WithServerURL("https://test-company-be.glean.com"),
 			glean.WithSecurity("test-token"),
 			glean.WithClient(mock),
 		), nil

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -18,7 +18,7 @@ import (
 // Width/height are set to non-zero so layout functions work.
 func newTestModel(t *testing.T) *Model {
 	t.Helper()
-	cfg := &config.Config{GleanHost: "test-be.glean.com", GleanToken: "tok"}
+	cfg := &config.Config{GleanServerURL: "https://test-be.glean.com", GleanToken: "tok"}
 	m, err := New(cfg, &Session{}, "test@example.com · test", "dev", context.Background())
 	require.NoError(t, err)
 	// Simulate a terminal size so layout calculations are predictable.

--- a/skills/glean-cli/SKILL.md
+++ b/skills/glean-cli/SKILL.md
@@ -35,7 +35,7 @@ glean auth status
 
 # CI/scripting (no interactive setup needed)
 export GLEAN_API_TOKEN=your-token
-export GLEAN_HOST=your-company-be.glean.com
+export GLEAN_SERVER_URL=<your Glean server URL>
 ```
 
 Credentials resolve in this order: environment variables → system keyring → ~/.glean/config.json.

--- a/snippets/readme/snippet-02.sh
+++ b/snippets/readme/snippet-02.sh
@@ -1,7 +1,7 @@
 # 1. Authenticate
 glean auth login                          # OAuth via browser (recommended)
 # — OR set env vars for CI/CD:
-# export GLEAN_HOST=your-company-be.glean.com GLEAN_API_TOKEN=your-token
+# export GLEAN_SERVER_URL=https://your-server-url GLEAN_API_TOKEN=your-token
 
 # 2. Search
 glean search "vacation policy"

--- a/snippets/readme/snippet-05.sh
+++ b/snippets/readme/snippet-05.sh
@@ -1,3 +1,3 @@
 export GLEAN_API_TOKEN=your-token
-export GLEAN_HOST=your-company-be.glean.com
+export GLEAN_SERVER_URL=https://your-server-url
 glean search "test"


### PR DESCRIPTION
Migrates the primary Glean connection variable from hostname to full server URL across the CLI, aligning with Glean's server-url migration.

Closes #102.

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `mise run build`
- [x] Manual: `glean auth login`, `glean auth status`, `glean search` end-to-end