### PR TITLE
deps: bump api-client-go to v0.13.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/fatih/color v1.19.0
 	github.com/gkampitakis/go-snaps v0.5.22
-	github.com/gleanwork/api-client-go v0.12.0
+	github.com/gleanwork/api-client-go v0.13.3
 	github.com/int128/oauth2cli v1.18.0
 	github.com/minio/selfupdate v0.6.0
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/gkampitakis/ciinfo v0.3.4 h1:5eBSibVuSMbb/H6Elc0IIEFbkzCJi3lm94n0+U7Z
 github.com/gkampitakis/ciinfo v0.3.4/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-snaps v0.5.22 h1:xg9omphRnbDnimMCl1KqznC4krlxOGpkB0vDSfX2P7M=
 github.com/gkampitakis/go-snaps v0.5.22/go.mod h1:uy3lVzCCRRsAwYqSocyw5fY8xRLCYEfqoOJNxr8HonM=
-github.com/gleanwork/api-client-go v0.12.0 h1:umtm2Fa1rRqFcBKWDpJwqGbekAysvb7jjvPSs78CB/c=
-github.com/gleanwork/api-client-go v0.12.0/go.mod h1:EL9EbKruPM+pb75cD1ivKVIaM86ysyro13Ssl/EDVTo=
+github.com/gleanwork/api-client-go v0.13.3 h1:CT+jYZVw+q8zSWZBbmWXsYKFH0x/66aFoI3RvXce7Yc=
+github.com/gleanwork/api-client-go v0.13.3/go.mod h1:EL9EbKruPM+pb75cD1ivKVIaM86ysyro13Ssl/EDVTo=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
 github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=


### PR DESCRIPTION
Pure dependency bump: brings in the platform API namespaces (Search, Agents on /api/* routes) and the WithIncludeExperimental SDK option needed for the platform-first migration. Classic client surface unchanged — zero code churn, snapshots untouched.

Discovery notes for the stack (verified from SDK source):
- Hidden 404 for gated experimental endpoints surfaces as PlatformProblemDetailError{Status:404, Code:resource_not_found} or generic APIError 404 — no dedicated gating code or header visible to clients.
- PlatformSearchRequest supports query, page_size, cursor, datasources, datasource_instances, filters, time_range.
- Agents.CreateRun takes agent_id as a path parameter, separate from the body.

Part 1/9 of the platform-API migration stack (sc/platform-01 → 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)