### PR TITLE
feat(cmdutil): teach Build the platform-first fallback protocol

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -12,28 +12,28 @@ func init() {
 	// Register schemas for all commands at startup.
 	schema.Register(schema.CommandSchema{
 		Command:     "search",
-		Description: "Search for content in your Glean instance. Results are JSON.",
+		Description: "Search for content in your Glean instance via the platform API (POST /api/search); responses use its snake_case shape. Falls back to the classic API with a warning when the platform API is not enabled; GLEAN_LEGACY_APIS=1 forces the classic API. Results are JSON.",
 		Flags: map[string]schema.FlagSchema{
-			"--json":                          {Type: "string", Description: "Complete JSON request body (overrides individual flags)", Required: false},
+			"--json":                          {Type: "string", Description: "Complete JSON request body in the platform shape: query, page_size, cursor, datasources, datasource_instances, filters, time_range (overrides individual flags). With GLEAN_LEGACY_APIS=1, parsed as the classic shape", Required: false},
 			"--query":                         {Type: "string", Description: "Search query (positional arg)", Required: true},
 			"--page-size":                     {Type: "integer", Default: 10, Description: "Number of results per page"},
-			"--max-snippet-size":              {Type: "integer", Default: 0, Description: "Maximum snippet size in characters"},
+			"--max-snippet-size":              {Type: "integer", Default: 0, Description: "Maximum snippet size in characters (legacy API only)"},
 			"--timeout":                       {Type: "integer", Default: 30000, Description: "Request timeout in milliseconds"},
-			"--disable-spellcheck":            {Type: "boolean", Default: false, Description: "Disable spellcheck"},
+			"--disable-spellcheck":            {Type: "boolean", Default: false, Description: "Disable spellcheck (legacy API only)"},
 			"--datasource":                    {Type: "[]string", Description: "Filter by datasource (repeatable)"},
 			"--type":                          {Type: "[]string", Description: "Filter by document type (repeatable)"},
-			"--tab":                           {Type: "[]string", Description: "Filter by result tab IDs (repeatable)"},
-			"--response-hints":                {Type: "[]string", Default: []string{"RESULTS", "QUERY_METADATA"}, Description: "Response hints"},
-			"--facet-bucket-size":             {Type: "integer", Default: 10, Description: "Maximum facet buckets per result"},
-			"--disable-query-autocorrect":     {Type: "boolean", Default: false, Description: "Disable automatic query corrections"},
-			"--fetch-all-datasource-counts":   {Type: "boolean", Default: false, Description: "Return counts for all datasources"},
-			"--query-overrides-facet-filters": {Type: "boolean", Default: false, Description: "Allow query operators to override facet filters"},
-			"--return-llm-content":            {Type: "boolean", Default: false, Description: "Return expanded LLM-friendly content"},
+			"--tab":                           {Type: "[]string", Description: "Filter by result tab IDs (repeatable, legacy API only)"},
+			"--response-hints":                {Type: "[]string", Default: []string{"RESULTS", "QUERY_METADATA"}, Description: "Response hints (legacy API only)"},
+			"--facet-bucket-size":             {Type: "integer", Default: 10, Description: "Maximum facet buckets per result (legacy API only)"},
+			"--disable-query-autocorrect":     {Type: "boolean", Default: false, Description: "Disable automatic query corrections (legacy API only)"},
+			"--fetch-all-datasource-counts":   {Type: "boolean", Default: false, Description: "Return counts for all datasources (legacy API only)"},
+			"--query-overrides-facet-filters": {Type: "boolean", Default: false, Description: "Allow query operators to override facet filters (legacy API only)"},
+			"--return-llm-content":            {Type: "boolean", Default: false, Description: "Return expanded LLM-friendly content (legacy API only)"},
 			"--output":                        {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json", Description: "Output format"},
 			"--dry-run":                       {Type: "boolean", Default: false, Description: "Print request body without sending"},
 		},
-		Example: `glean search "vacation policy" | jq '.results[].document.title'
-glean search --json '{"query":"Q1 reports","pageSize":5,"datasources":["confluence"]}' | jq .`,
+		Example: `glean search "vacation policy" | jq '.results[].title'
+glean search --json '{"query":"Q1 reports","page_size":5,"datasources":["confluence"]}' | jq .`,
 	})
 
 	schema.Register(schema.CommandSchema{

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,15 +10,42 @@ import (
 	"github.com/gleanwork/api-client-go/models/components"
 	gleanClient "github.com/gleanwork/glean-cli/internal/client"
 	"github.com/gleanwork/glean-cli/internal/output"
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/gleanwork/glean-cli/internal/search"
 	"github.com/spf13/cobra"
 )
 
+// searchTextFn renders whichever search response shape the request produced:
+// the platform response (default) or the classic response (legacy fallback).
 func searchTextFn(w io.Writer, v any) error {
-	resp, ok := v.(*components.SearchResponse)
-	if !ok {
+	switch resp := v.(type) {
+	case *components.PlatformSearchResponse:
+		return platformSearchTextFn(w, resp)
+	case *components.SearchResponse:
+		return legacySearchTextFn(w, resp)
+	default:
 		return output.WriteJSON(w, v)
 	}
+}
+
+func platformSearchTextFn(w io.Writer, resp *components.PlatformSearchResponse) error {
+	var rows [][]string
+	for _, r := range resp.Results {
+		snippet := ""
+		if len(r.Snippets) > 0 {
+			snippet = r.Snippets[0]
+		}
+		rows = append(rows, []string{
+			output.Truncate(r.Title, 50),
+			r.Datasource,
+			r.URL,
+			output.Truncate(snippet, 60),
+		})
+	}
+	return output.WriteTable(w, []string{"TITLE", "SOURCE", "URL", "SNIPPET"}, rows)
+}
+
+func legacySearchTextFn(w io.Writer, resp *components.SearchResponse) error {
 	var rows [][]string
 	for _, r := range resp.Results {
 		title, source, url, snippet := "", "", "", ""
@@ -70,14 +98,19 @@ func NewCmdSearch() *cobra.Command {
 		Short: "Search for content in your Glean instance",
 		Long: `Search for content in your Glean instance.
 
+Search is served by the platform API (POST /api/search) and results use its
+snake_case response shape. If the platform API is not enabled on your
+instance, the command falls back to the classic API with a warning; set
+GLEAN_LEGACY_APIS=1 to use the classic API directly.
+
 Results are written as JSON to stdout by default, making the output easy to
 pipe to jq or other tools.
 
 Example:
   glean search "vacation policy"
-  glean search "vacation policy" | jq '.results[].document.title'
-  glean search --json '{"query":"Q1 reports","pageSize":5}' | jq .
-  glean search --output ndjson "engineering docs" | head -3 | jq .document.title
+  glean search "vacation policy" | jq '.results[].title'
+  glean search --json '{"query":"Q1 reports","page_size":5}' | jq .
+  glean search --output ndjson "engineering docs" | head -3 | jq .title
   glean search --dry-run "test"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,9 +118,14 @@ Example:
 				return fmt.Errorf("requires a query argument or --json payload")
 			}
 
-			// --json path: parse directly into SearchRequest
+			// --json path: the payload shape is coupled to the endpoint, so a
+			// user-authored body is never replayed against the other surface.
+			// Platform shape by default; classic shape under GLEAN_LEGACY_APIS=1.
 			if jsonPayload != "" {
-				var req components.SearchRequest
+				if platform.Legacy() {
+					return runLegacyJSONSearch(cmd, jsonPayload, dryRun, outputFormat, raw)
+				}
+				var req components.PlatformSearchRequest
 				if err := json.Unmarshal([]byte(jsonPayload), &req); err != nil {
 					return fmt.Errorf("invalid --json payload: %w", err)
 				}
@@ -98,23 +136,14 @@ Example:
 				if err != nil {
 					return err
 				}
-				resp, err := sdk.Client.Search.Query(cmd.Context(), req, nil)
+				resp, err := sdk.Search.Query(cmd.Context(), req)
 				if err != nil {
+					if platform.IsGateClosed(err) {
+						return platform.GateClosedErr("/api/search", err)
+					}
 					return fmt.Errorf("search request failed: %w", err)
 				}
-				// Text output operates on the raw SDK struct directly;
-				// cleansing is redundant since the table selects its own fields.
-				if outputFormat == output.OutputText {
-					return output.WriteFormatted(cmd.OutOrStdout(), resp.SearchResponse, outputFormat, searchTextFn)
-				}
-				var result any = resp.SearchResponse
-				if !raw {
-					result, err = output.CleanseSearchResponse(result)
-					if err != nil {
-						return err
-					}
-				}
-				return output.WriteFormatted(cmd.OutOrStdout(), result, outputFormat, searchTextFn)
+				return output.WriteFormatted(cmd.OutOrStdout(), resp.PlatformSearchResponse, outputFormat, searchTextFn)
 			}
 
 			// flag-based path
@@ -153,31 +182,46 @@ Example:
 			opts.Query = args[0]
 
 			if dryRun {
-				return output.WriteJSON(cmd.OutOrStdout(), search.BuildSearchRequest(opts))
+				if platform.Legacy() {
+					return output.WriteJSON(cmd.OutOrStdout(), search.BuildSearchRequest(opts))
+				}
+				return output.WriteJSON(cmd.OutOrStdout(), search.BuildPlatformSearchRequest(opts))
 			}
 
 			sdk, err := gleanClient.NewFromConfig()
 			if err != nil {
 				return err
 			}
-			resp, err := search.RunSearchSDK(cmd.Context(), opts, sdk)
+			if !platform.Legacy() {
+				if ignored := platformIgnoredFlags(cmd); len(ignored) > 0 {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"Note: flags ignored by platform search (legacy-only): %s\n",
+						strings.Join(ignored, ", "))
+				}
+			}
+
+			result, viaLegacy, err := platform.Run(cmd.Context(), cmd.ErrOrStderr(), "/api/search",
+				func(ctx context.Context) (any, error) { return search.RunPlatformSearch(ctx, opts, sdk) },
+				func(ctx context.Context) (any, error) { return search.RunSearchSDK(ctx, opts, sdk) },
+			)
 			if err != nil {
 				return err
 			}
 			// Text output operates on the raw SDK struct directly;
 			// cleansing is redundant since the table selects its own fields.
 			if outputFormat == output.OutputText {
-				return output.WriteFormatted(cmd.OutOrStdout(), resp, outputFormat, searchTextFn)
+				return output.WriteFormatted(cmd.OutOrStdout(), result, outputFormat, searchTextFn)
 			}
-			var result any = resp
-			if !raw {
+			// The classic response carries superfluous properties and is
+			// cleansed unless --raw; platform responses are emitted as-is.
+			if viaLegacy && !raw {
 				result, err = output.CleanseSearchResponse(result)
 				if err != nil {
 					return err
 				}
 			}
 			if fields != "" {
-				if !raw {
+				if viaLegacy && !raw {
 					if stripped := output.WarnStrippedFields(fields); len(stripped) > 0 {
 						fmt.Fprintf(cmd.ErrOrStderr(),
 							"Warning: field(s) %s not available in cleansed output (use --raw for the full response)\n",
@@ -190,11 +234,11 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&jsonPayload, "json", "", "Complete JSON request body (overrides all other flags)")
+	cmd.Flags().StringVar(&jsonPayload, "json", "", "Complete JSON request body in the platform shape (overrides all other flags); with GLEAN_LEGACY_APIS=1, parsed as the classic shape")
 	cmd.Flags().StringVar(&outputFormat, "output", "json", "Output format: json, ndjson, or text")
 	cmd.Flags().StringVar(&fields, "fields", "", "Comma-separated dot-path fields to include (e.g. results.document.title,results.document.url). Results where all projected fields are missing appear as {}")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the request body without sending it")
-	cmd.Flags().BoolVar(&raw, "raw", false, "Output the full SDK response without cleansing")
+	cmd.Flags().BoolVar(&raw, "raw", false, "Output the full SDK response without cleansing (classic API responses only; platform responses are never cleansed)")
 	cmd.Flags().IntVar(&opts.PageSize, "page-size", 10, "Number of results per page")
 	cmd.Flags().IntVar(&opts.MaxSnippetSize, "max-snippet-size", 0, "Maximum size of snippets")
 	cmd.Flags().IntVar(&opts.TimeoutMillis, "timeout", 30000, "Request timeout in milliseconds")
@@ -212,4 +256,63 @@ Example:
 	cmd.Flags().Int("facet-bucket-size", 10, "Maximum number of facet buckets to return")
 
 	return cmd
+}
+
+// platformIgnoredFlags returns the explicitly-set search flags that have no
+// platform API equivalent, so users learn their flag did nothing rather than
+// silently getting unfiltered results.
+func platformIgnoredFlags(cmd *cobra.Command) []string {
+	legacyOnly := []string{
+		"max-snippet-size",
+		"disable-spellcheck",
+		"tab",
+		"response-hints",
+		"facet-bucket-size",
+		"disable-query-autocorrect",
+		"fetch-all-datasource-counts",
+		"query-overrides-facet-filters",
+		"return-llm-content",
+	}
+	var ignored []string
+	for _, name := range legacyOnly {
+		if cmd.Flags().Changed(name) {
+			ignored = append(ignored, "--"+name)
+		}
+	}
+	return ignored
+}
+
+// runLegacyJSONSearch handles --json under GLEAN_LEGACY_APIS=1: the payload
+// is parsed as the classic /rest/api/v1/search request shape and the
+// response is cleansed unless --raw, exactly as before the platform
+// migration.
+func runLegacyJSONSearch(cmd *cobra.Command, jsonPayload string, dryRun bool, outputFormat string, raw bool) error {
+	var req components.SearchRequest
+	if err := json.Unmarshal([]byte(jsonPayload), &req); err != nil {
+		return fmt.Errorf("invalid --json payload: %w", err)
+	}
+	if dryRun {
+		return output.WriteJSON(cmd.OutOrStdout(), req)
+	}
+	sdk, err := gleanClient.NewFromConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := sdk.Client.Search.Query(cmd.Context(), req, nil)
+	if err != nil {
+		return fmt.Errorf("search request failed: %w", err)
+	}
+	// Text output operates on the raw SDK struct directly;
+	// cleansing is redundant since the table selects its own fields.
+	if outputFormat == output.OutputText {
+		return output.WriteFormatted(cmd.OutOrStdout(), resp.SearchResponse, outputFormat, searchTextFn)
+	}
+	var result any = resp.SearchResponse
+	if !raw {
+		result, err = output.CleanseSearchResponse(result)
+		if err != nil {
+			return err
+		}
+	}
+	return output.WriteFormatted(cmd.OutOrStdout(), result, outputFormat, searchTextFn)
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -5,13 +5,41 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/gleanwork/glean-cli/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// searchResponse builds a minimal Glean SearchResponse JSON body with the given document titles.
-func searchResponse(titles ...string) []byte {
+const (
+	platformSearchPath = "/api/search"
+	legacySearchPath   = "/rest/api/v1/search"
+)
+
+// platformSearchResponse builds a minimal platform search response body with
+// the given result titles.
+func platformSearchResponse(titles ...string) []byte {
+	type result struct {
+		URL        string   `json:"url"`
+		Title      string   `json:"title"`
+		Datasource string   `json:"datasource"`
+		Snippets   []string `json:"snippets,omitempty"`
+	}
+	rs := []result{}
+	for _, title := range titles {
+		rs = append(rs, result{URL: "https://docs.example.com", Title: title, Datasource: "gdrive"})
+	}
+	b, _ := json.Marshal(map[string]any{
+		"results":     rs,
+		"has_more":    false,
+		"next_cursor": nil,
+		"request_id":  "req-test",
+	})
+	return b
+}
+
+// legacySearchResponse builds a minimal classic SearchResponse JSON body with the given document titles.
+func legacySearchResponse(titles ...string) []byte {
 	type doc struct {
 		Title string `json:"title"`
 	}
@@ -28,8 +56,26 @@ func searchResponse(titles ...string) []byte {
 	return b
 }
 
-func TestSearchCommand_BasicQuery(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, searchResponse("Vacation Policy", "Holiday Guide"))
+// gateClosedResponse is the hidden-404 problem detail the platform stack
+// returns when experimental endpoints are not enabled for the tenant.
+func gateClosedResponse() testutils.MockResponse {
+	return testutils.MockResponse{
+		StatusCode:  404,
+		ContentType: "application/problem+json",
+		Body:        []byte(`{"type":"about:blank","title":"Not Found","status":404,"detail":"resource not found","code":"resource_not_found","request_id":"req-gate"}`),
+	}
+}
+
+// usePlatformAPIs pins the test to platform-first behavior regardless of the
+// developer's own GLEAN_LEGACY_APIS setting.
+func usePlatformAPIs(t *testing.T) {
+	t.Helper()
+	t.Setenv(platform.EnvLegacy, "")
+}
+
+func TestSearchCommand_BasicQuery_UsesPlatformAPI(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Vacation Policy", "Holiday Guide"))
 	defer cleanup()
 
 	root := NewCmdRoot()
@@ -39,6 +85,69 @@ func TestSearchCommand_BasicQuery(t *testing.T) {
 	err := root.Execute()
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Vacation Policy")
+
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, platformSearchPath, mock.Requests[0].URL.Path)
+}
+
+func TestSearchCommand_PlatformOutputNotCleansed(t *testing.T) {
+	usePlatformAPIs(t)
+	_, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Doc"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"search", "doc"})
+	require.NoError(t, root.Execute())
+
+	// Platform responses are emitted as-is: snake_case fields survive.
+	assert.Contains(t, buf.String(), "request_id")
+	assert.Contains(t, buf.String(), "has_more")
+}
+
+func TestSearchCommand_GateClosedFallsBackToLegacy(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, nil)
+	defer cleanup()
+	mock.Routes = map[string]testutils.MockResponse{
+		platformSearchPath: gateClosedResponse(),
+		legacySearchPath:   {Body: legacySearchResponse("Legacy Doc")},
+	}
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"search", "doc"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, buf.String(), "Legacy Doc")
+	assert.Contains(t, errBuf.String(), "falling back to the legacy API")
+
+	require.Len(t, mock.Requests, 2, "platform attempt then legacy fallback")
+	assert.Equal(t, platformSearchPath, mock.Requests[0].URL.Path)
+	assert.Equal(t, legacySearchPath, mock.Requests[1].URL.Path)
+}
+
+func TestSearchCommand_LegacyEnvSkipsPlatform(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	mock, cleanup := testutils.SetupTestWithResponse(t, legacySearchResponse("Legacy Doc"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"search", "doc"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, buf.String(), "Legacy Doc")
+	assert.NotContains(t, errBuf.String(), "Warning")
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, legacySearchPath, mock.Requests[0].URL.Path)
 }
 
 func TestSearchCommand_MissingQuery(t *testing.T) {
@@ -52,6 +161,7 @@ func TestSearchCommand_MissingQuery(t *testing.T) {
 }
 
 func TestSearchCommand_DryRun(t *testing.T) {
+	usePlatformAPIs(t)
 	// Dry-run should not require credentials — SDK init is deferred until after the dry-run check.
 	root := NewCmdRoot()
 	buf := &bytes.Buffer{}
@@ -62,42 +172,106 @@ func TestSearchCommand_DryRun(t *testing.T) {
 	var req map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &req), "dry-run output must be valid JSON")
 	assert.Equal(t, "test query", req["query"])
+	assert.Equal(t, float64(10), req["page_size"], "dry-run shows the platform request shape")
 }
 
-func TestSearchCommand_JSONPayload(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, searchResponse("Engineering Docs"))
+func TestSearchCommand_DryRun_LegacyEnv(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"search", "--dry-run", "test query"})
+	require.NoError(t, root.Execute())
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &req))
+	assert.Equal(t, "test query", req["query"])
+	assert.Contains(t, buf.String(), "pageSize", "legacy dry-run shows the classic camelCase shape")
+}
+
+func TestSearchCommand_JSONPayload_Platform(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Engineering Docs"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"search", "--json", `{"query":"engineering","page_size":5}`})
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Engineering Docs")
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, platformSearchPath, mock.Requests[0].URL.Path)
+}
+
+func TestSearchCommand_JSONPayload_GateClosedErrors(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, nil)
+	defer cleanup()
+	mock.Routes = map[string]testutils.MockResponse{
+		platformSearchPath: gateClosedResponse(),
+	}
+
+	root := NewCmdRoot()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"search", "--json", `{"query":"engineering"}`})
+	err := root.Execute()
+	require.Error(t, err, "user-authored payloads must not silently fall back")
+	assert.Contains(t, err.Error(), platform.EnvLegacy)
+	require.Len(t, mock.Requests, 1, "no legacy retry for --json payloads")
+}
+
+func TestSearchCommand_JSONPayload_LegacyEnv(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	mock, cleanup := testutils.SetupTestWithResponse(t, legacySearchResponse("Engineering Docs"))
 	defer cleanup()
 
 	root := NewCmdRoot()
 	buf := &bytes.Buffer{}
 	root.SetOut(buf)
 	root.SetArgs([]string{"search", "--json", `{"query":"engineering","pageSize":5}`})
-	err := root.Execute()
-	require.NoError(t, err)
+	require.NoError(t, root.Execute())
 	assert.Contains(t, buf.String(), "Engineering Docs")
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, legacySearchPath, mock.Requests[0].URL.Path)
+}
+
+func TestSearchCommand_IgnoredFlagsNote(t *testing.T) {
+	usePlatformAPIs(t)
+	_, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Doc"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	errBuf := &bytes.Buffer{}
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"search", "--facet-bucket-size", "5", "--return-llm-content", "doc"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, errBuf.String(), "flags ignored by platform search")
+	assert.Contains(t, errBuf.String(), "--facet-bucket-size")
+	assert.Contains(t, errBuf.String(), "--return-llm-content")
 }
 
 func TestSearchCommand_OutputText(t *testing.T) {
+	usePlatformAPIs(t)
 	body, _ := json.Marshal(map[string]any{
 		"results": []map[string]any{
 			{
-				"document": map[string]any{
-					"title":      "Vacation Policy",
-					"datasource": "gdrive",
-					"url":        "https://docs.example.com/vacation",
-				},
-				"snippets": []map[string]any{
-					{"text": "All employees are entitled to 20 days PTO"},
-				},
+				"title":      "Vacation Policy",
+				"datasource": "gdrive",
+				"url":        "https://docs.example.com/vacation",
+				"snippets":   []string{"All employees are entitled to 20 days PTO"},
 			},
 			{
-				"document": map[string]any{
-					"title":      "Holiday Guide",
-					"datasource": "confluence",
-					"url":        "https://wiki.example.com/holidays",
-				},
+				"title":      "Holiday Guide",
+				"datasource": "confluence",
+				"url":        "https://wiki.example.com/holidays",
 			},
 		},
+		"has_more":   false,
+		"request_id": "req-test",
 	})
 	_, cleanup := testutils.SetupTestWithResponse(t, body)
 	defer cleanup()
@@ -121,7 +295,8 @@ func TestSearchCommand_OutputText(t *testing.T) {
 }
 
 func TestSearchCommand_OutputNDJSON(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, searchResponse("Doc A", "Doc B"))
+	usePlatformAPIs(t)
+	_, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Doc A", "Doc B"))
 	defer cleanup()
 
 	root := NewCmdRoot()

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -21,7 +21,23 @@ import (
 	glean "github.com/gleanwork/api-client-go"
 	gleanClient "github.com/gleanwork/glean-cli/internal/client"
 	"github.com/gleanwork/glean-cli/internal/output"
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/spf13/cobra"
+)
+
+// FallbackMode controls what a platform-first command (Spec.LegacyRun != nil)
+// does when the platform endpoint is gated off (hidden 404).
+type FallbackMode int
+
+const (
+	// FallbackAuto retries via LegacyRun with a one-time warning. Use for
+	// commands whose request the CLI built itself (or whose input is
+	// surface-agnostic, like a bare ID).
+	FallbackAuto FallbackMode = iota
+	// FallbackEnvOnly never retries automatically: gate-closed produces an
+	// actionable error naming GLEAN_LEGACY_APIS. Use for commands whose
+	// --json body is user-authored and coupled to the endpoint's shape.
+	FallbackEnvOnly
 )
 
 // Spec describes a single SDK-backed subcommand.
@@ -33,6 +49,23 @@ type Spec[Req any] struct {
 	// JSONRequired causes an error when --json is absent.
 	// Set false for list/read commands where the request body is optional.
 	JSONRequired bool
+
+	// Endpoint is the platform API path used in fallback warnings and
+	// gate-closed errors (e.g. "/api/agents/search"). Required when
+	// LegacyRun is set.
+	Endpoint string
+
+	// FallbackMode selects the gate-closed behavior when LegacyRun is set.
+	// The zero value is FallbackAuto.
+	FallbackMode FallbackMode
+
+	// LegacyRun, when non-nil, marks this command platform-first: Run is the
+	// platform API call, and LegacyRun serves the classic API instead when
+	// GLEAN_LEGACY_APIS=1 or as the gate-closed fallback (FallbackAuto).
+	// It receives the normalized --json bytes (snake_case keys — the CLI's
+	// canonical input shape) so it can unmarshal the classic request type,
+	// which differs from the platform Req type.
+	LegacyRun func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error)
 
 	// ErrTransform optionally remaps errors returned by json.Unmarshal before
 	// they are surfaced to the user. Use it to replace Go type names in SDK
@@ -50,6 +83,7 @@ type Spec[Req any] struct {
 	// The payload must be the inner component field — NOT the operation wrapper
 	// (e.g. return resp.ListCollectionsResponse, not resp).
 	// Return (nil, nil) for operations with no response body (delete, etc.).
+	// When LegacyRun is set, Run is the platform API call.
 	Run func(ctx context.Context, sdk *glean.Glean, req Req) (any, error)
 }
 
@@ -74,9 +108,18 @@ func Build[Req any](spec Spec[Req]) *cobra.Command {
 				return fmt.Errorf("--json is required\n\nRun '%s --help' for the expected payload format", cmd.CommandPath())
 			}
 
-			var req Req
+			var normalized []byte
 			if jsonPayload != "" {
-				normalized := normalizeKeys([]byte(jsonPayload), aliases)
+				normalized = normalizeKeys([]byte(jsonPayload), aliases)
+			}
+
+			// In legacy mode the payload is parsed by LegacyRun against the
+			// classic request type, so skip the platform-type parse (the two
+			// shapes differ and a legacy payload may not satisfy it).
+			legacyMode := spec.LegacyRun != nil && platform.Legacy()
+
+			var req Req
+			if len(normalized) > 0 && !legacyMode {
 				if err := json.Unmarshal(normalized, &req); err != nil {
 					if spec.ErrTransform != nil {
 						return spec.ErrTransform(err)
@@ -86,6 +129,17 @@ func Build[Req any](spec Spec[Req]) *cobra.Command {
 			}
 
 			if dryRun {
+				if legacyMode {
+					// The classic request type is known only to LegacyRun;
+					// show the normalized payload as-is.
+					payload := map[string]any{}
+					if len(normalized) > 0 {
+						if err := json.Unmarshal(normalized, &payload); err != nil {
+							return fmt.Errorf("invalid --json: %w", err)
+						}
+					}
+					return output.WriteJSON(cmd.OutOrStdout(), payload)
+				}
 				return output.WriteJSON(cmd.OutOrStdout(), req)
 			}
 
@@ -94,7 +148,23 @@ func Build[Req any](spec Spec[Req]) *cobra.Command {
 				return err
 			}
 
-			result, err := spec.Run(cmd.Context(), sdk, req)
+			var result any
+			switch {
+			case spec.LegacyRun == nil:
+				result, err = spec.Run(cmd.Context(), sdk, req)
+			case legacyMode:
+				result, err = spec.LegacyRun(cmd.Context(), sdk, normalized)
+			case spec.FallbackMode == FallbackEnvOnly:
+				result, err = spec.Run(cmd.Context(), sdk, req)
+				if err != nil && platform.IsGateClosed(err) {
+					return platform.GateClosedErr(spec.Endpoint, err)
+				}
+			default: // FallbackAuto
+				result, _, err = platform.Run(cmd.Context(), cmd.ErrOrStderr(), spec.Endpoint,
+					func(ctx context.Context) (any, error) { return spec.Run(ctx, sdk, req) },
+					func(ctx context.Context) (any, error) { return spec.LegacyRun(ctx, sdk, normalized) },
+				)
+			}
 			if err != nil {
 				return err
 			}

--- a/internal/cmdutil/factory_test.go
+++ b/internal/cmdutil/factory_test.go
@@ -1,0 +1,189 @@
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	glean "github.com/gleanwork/api-client-go"
+	"github.com/gleanwork/api-client-go/models/apierrors"
+	"github.com/gleanwork/glean-cli/internal/platform"
+	"github.com/gleanwork/glean-cli/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeReq is a platform-shaped request type with a snake_case JSON tag so
+// buildAliases produces the agentId → agent_id normalization.
+type fakeReq struct {
+	AgentID string `json:"agent_id"`
+}
+
+func gateClosed() error {
+	return &apierrors.PlatformProblemDetailError{Status: http.StatusNotFound}
+}
+
+// execSpec builds the command from spec, executes it with args, and returns
+// stdout, stderr, and the execution error.
+func execSpec(t *testing.T, spec Spec[fakeReq], args ...string) (string, string, error) {
+	t.Helper()
+	_, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+	defer cleanup()
+
+	cmd := Build(spec)
+	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestBuild_PlatformFirst_Success(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:      "get",
+		Endpoint: "/api/agents/{agent_id}",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return map[string]string{"via": "platform", "id": req.AgentID}, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			t.Fatal("LegacyRun must not run on platform success")
+			return nil, nil
+		},
+	}
+	out, errOut, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"via": "platform"`)
+	assert.Contains(t, out, `"id": "a-1"`, "camelCase input must normalize to the snake_case platform field")
+	assert.Empty(t, errOut)
+}
+
+func TestBuild_FallbackAuto_GateClosedUsesLegacy(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:      "get",
+		Endpoint: "/api/agents/{agent_id}",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return nil, gateClosed()
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			var m map[string]string
+			require.NoError(t, json.Unmarshal(rawJSON, &m))
+			return map[string]string{"via": "legacy", "id": m["agent_id"]}, nil
+		},
+	}
+	out, errOut, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"via": "legacy"`)
+	assert.Contains(t, out, `"id": "a-1"`, "LegacyRun receives the normalized snake_case payload")
+	assert.Contains(t, errOut, "falling back to the legacy API")
+}
+
+func TestBuild_FallbackEnvOnly_GateClosedErrors(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:          "run",
+		Endpoint:     "/api/agents/{agent_id}/runs",
+		FallbackMode: FallbackEnvOnly,
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return nil, gateClosed()
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			t.Fatal("LegacyRun must not auto-run in EnvOnly mode")
+			return nil, nil
+		},
+	}
+	_, _, err := execSpec(t, spec, "--json", `{"agent_id":"a-1"}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), platform.EnvLegacy)
+	assert.Contains(t, err.Error(), "/api/agents/{agent_id}/runs")
+}
+
+func TestBuild_FallbackEnvOnly_NonGateErrorPassesThrough(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:          "run",
+		Endpoint:     "/api/agents/{agent_id}/runs",
+		FallbackMode: FallbackEnvOnly,
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return nil, &apierrors.PlatformProblemDetailError{Status: http.StatusUnauthorized, Title: "auth required"}
+		},
+	}
+	_, _, err := execSpec(t, spec, "--json", `{"agent_id":"a-1"}`)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), platform.EnvLegacy, "non-404 errors are not gate-closed guidance")
+}
+
+func TestBuild_LegacyEnv_UsesLegacyRunDirectly(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "1")
+
+	spec := Spec[fakeReq]{
+		Use:      "get",
+		Endpoint: "/api/agents/{agent_id}",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			t.Fatal("platform Run must not execute in legacy mode")
+			return nil, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			return map[string]string{"via": "legacy"}, nil
+		},
+	}
+	out, errOut, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"via": "legacy"`)
+	assert.Empty(t, errOut, "explicit legacy opt-out produces no warning")
+}
+
+func TestBuild_NoLegacyRun_BehavesClassically(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use: "get",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return map[string]string{"id": req.AgentID}, nil
+		},
+	}
+	out, _, err := execSpec(t, spec, "--json", `{"agent_id":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id": "a-1"`)
+}
+
+func TestBuild_DryRun_PlatformShape(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:       "get",
+		Endpoint:  "/api/agents/{agent_id}",
+		Run:       func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) { return nil, nil },
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) { return nil, nil },
+	}
+	out, _, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`, "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"agent_id": "a-1"`)
+}
+
+func TestBuild_DryRun_LegacyEnvShowsNormalizedPayload(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+
+	spec := Spec[fakeReq]{
+		Use:       "get",
+		Endpoint:  "/api/agents/{agent_id}",
+		Run:       func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) { return nil, nil },
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) { return nil, nil },
+	}
+	out, _, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`, "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"agent_id": "a-1"`)
+}

--- a/internal/search/platform.go
+++ b/internal/search/platform.go
@@ -1,0 +1,72 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	glean "github.com/gleanwork/api-client-go"
+	"github.com/gleanwork/api-client-go/models/components"
+)
+
+// datasourceField is the facet filter field that both API surfaces route to
+// a dedicated datasource filter instead of the generic filter mechanism.
+const datasourceField = "datasource"
+
+// BuildPlatformSearchRequest converts Options into the platform API's
+// components.PlatformSearchRequest. The platform surface is deliberately
+// narrower than the classic SearchRequest: flags without a platform
+// equivalent are simply not mapped (cmd/search reports those to the user via
+// flags.Changed, which knows what was explicitly set).
+func BuildPlatformSearchRequest(opts *Options) components.PlatformSearchRequest {
+	req := components.PlatformSearchRequest{
+		Query: opts.Query,
+	}
+
+	if opts.PageSize > 0 {
+		pageSize := int64(opts.PageSize)
+		req.PageSize = &pageSize
+	}
+	if opts.Cursor != "" {
+		cursor := opts.Cursor
+		req.Cursor = &cursor
+	}
+
+	if opts.RequestOptions != nil {
+		for _, ff := range opts.RequestOptions.FacetFilters {
+			// Mirror the classic builder: datasource filtering uses the
+			// dedicated field, not the generic filter mechanism.
+			if ff.FieldName == datasourceField {
+				for _, v := range ff.Values {
+					req.Datasources = append(req.Datasources, v.Value)
+				}
+				continue
+			}
+			filter := components.PlatformFilter{Field: ff.FieldName}
+			for _, v := range ff.Values {
+				filter.Values = append(filter.Values, v.Value)
+			}
+			req.Filters = append(req.Filters, filter)
+		}
+	}
+
+	return req
+}
+
+// RunPlatformSearch executes a search against the platform API
+// (POST /api/search) and returns the raw platform response. The classic
+// request carries timeoutMillis in the body; the platform API does not, so
+// --timeout is honored via a context deadline instead.
+func RunPlatformSearch(ctx context.Context, opts *Options, sdk *glean.Glean) (*components.PlatformSearchResponse, error) {
+	if opts.TimeoutMillis > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(opts.TimeoutMillis)*time.Millisecond)
+		defer cancel()
+	}
+
+	result, err := sdk.Search.Query(ctx, BuildPlatformSearchRequest(opts))
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	return result.PlatformSearchResponse, nil
+}

--- a/internal/search/platform_test.go
+++ b/internal/search/platform_test.go
@@ -1,0 +1,88 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	glean "github.com/gleanwork/api-client-go"
+	"github.com/gleanwork/glean-cli/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPlatformSearchRequest_Basic(t *testing.T) {
+	opts := &Options{Query: "vacation policy", PageSize: 25}
+	req := BuildPlatformSearchRequest(opts)
+
+	assert.Equal(t, "vacation policy", req.Query)
+	require.NotNil(t, req.PageSize)
+	assert.Equal(t, int64(25), *req.PageSize)
+	assert.Nil(t, req.Cursor)
+	assert.Empty(t, req.Datasources)
+	assert.Empty(t, req.Filters)
+}
+
+func TestBuildPlatformSearchRequest_ZeroPageSizeOmitted(t *testing.T) {
+	req := BuildPlatformSearchRequest(&Options{Query: "q"})
+	assert.Nil(t, req.PageSize, "unset page size defers to the API default")
+}
+
+func TestBuildPlatformSearchRequest_Cursor(t *testing.T) {
+	req := BuildPlatformSearchRequest(&Options{Query: "q", Cursor: "next-page-token"})
+	require.NotNil(t, req.Cursor)
+	assert.Equal(t, "next-page-token", *req.Cursor)
+}
+
+func TestBuildPlatformSearchRequest_DatasourceUsesDedicatedField(t *testing.T) {
+	opts := &Options{Query: "q", RequestOptions: &RequestOptions{}}
+	AddFacetFilter(opts, "datasource", []string{"confluence", "slack"})
+	AddFacetFilter(opts, "type", []string{"document"})
+
+	req := BuildPlatformSearchRequest(opts)
+
+	assert.Equal(t, []string{"confluence", "slack"}, req.Datasources)
+	require.Len(t, req.Filters, 1)
+	assert.Equal(t, "type", req.Filters[0].Field)
+	assert.Equal(t, []string{"document"}, req.Filters[0].Values)
+}
+
+func TestRunPlatformSearch_HitsPlatformEndpoint(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"results": []map[string]any{{
+			"url":        "https://example.com/doc",
+			"title":      "Example Doc",
+			"datasource": "confluence",
+			"snippets":   []string{"an excerpt"},
+		}},
+		"has_more":   false,
+		"request_id": "req-123",
+	})
+	require.NoError(t, err)
+
+	mock := &testutils.MockTransport{Body: body, ContentType: "application/json"}
+	sdk := glean.New(
+		glean.WithServerURL("https://test-company-be.glean.com"),
+		glean.WithSecurity("test-token"),
+		glean.WithClient(mock),
+	)
+
+	resp, err := RunPlatformSearch(context.Background(), &Options{Query: "example", TimeoutMillis: 5000}, sdk)
+	require.NoError(t, err)
+
+	require.Len(t, mock.Requests, 1)
+	sent := mock.Requests[0]
+	assert.Equal(t, "/api/search", sent.URL.Path)
+	assert.Equal(t, http.MethodPost, sent.Method)
+
+	sentBody, err := io.ReadAll(sent.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(sentBody), `"query":"example"`)
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "Example Doc", resp.Results[0].Title)
+	assert.Equal(t, "req-123", resp.RequestID)
+}

--- a/internal/search/utils.go
+++ b/internal/search/utils.go
@@ -65,7 +65,7 @@ func BuildSearchRequest(opts *Options) components.SearchRequest {
 			// The Glean API has a dedicated DatasourcesFilter field that must
 			// be used for datasource filtering — the generic FacetFilters
 			// mechanism does not filter by datasource correctly.
-			if ff.FieldName == "datasource" {
+			if ff.FieldName == datasourceField {
 				for _, v := range ff.Values {
 					sdkOpts.DatasourcesFilter = append(sdkOpts.DatasourcesFilter, v.Value)
 				}

--- a/internal/testutils/mock_client.go
+++ b/internal/testutils/mock_client.go
@@ -12,6 +12,17 @@ import (
 	"github.com/gleanwork/glean-cli/internal/config"
 )
 
+// MockResponse is a canned response for a specific request path, used via
+// MockTransport.Routes to give the platform and legacy endpoints different
+// behavior (e.g. platform 404 → legacy 200 fallback tests).
+type MockResponse struct {
+	// StatusCode defaults to 200 when zero
+	StatusCode int
+	Body       []byte
+	// ContentType defaults to the request's Accept header (see Do)
+	ContentType string
+}
+
 // MockTransport implements http.RoundTripper (the Do method expected by glean.HTTPClient).
 // It returns a predefined response body for every request, making it easy to test
 // command output without making real network calls.
@@ -24,6 +35,8 @@ type MockTransport struct {
 	StatusCode int
 	// ContentType defaults to "application/json" when empty
 	ContentType string
+	// Routes overrides the response per request URL path when the path is present
+	Routes map[string]MockResponse
 	// Requests records all requests received for inspection
 	Requests []*http.Request
 }
@@ -33,13 +46,19 @@ func (m *MockTransport) Do(req *http.Request) (*http.Response, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
+	body := m.Body
 	statusCode := m.StatusCode
+	contentType := m.ContentType
+	if route, ok := m.Routes[req.URL.Path]; ok {
+		body = route.Body
+		statusCode = route.StatusCode
+		contentType = route.ContentType
+	}
 	if statusCode == 0 {
 		statusCode = 200
 	}
 	// Mirror the Accept header the SDK sends so the SDK can parse its own response.
 	// CreateStream sets Accept: text/plain; Create sets Accept: application/json.
-	contentType := m.ContentType
 	if contentType == "" {
 		if accept := req.Header.Get("Accept"); accept != "" {
 			contentType = accept
@@ -50,7 +69,7 @@ func (m *MockTransport) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: statusCode,
 		Header:     http.Header{"Content-Type": []string{contentType}},
-		Body:       io.NopCloser(bytes.NewReader(m.Body)),
+		Body:       io.NopCloser(bytes.NewReader(body)),
 	}, nil
 }
 


### PR DESCRIPTION
cmdutil.Spec gains Endpoint, FallbackMode (Auto | EnvOnly), and LegacyRun. When LegacyRun is set, Run is the platform call: gate-closed 404s either retry via LegacyRun with a one-time warning (Auto) or produce an actionable error naming GLEAN_LEGACY_APIS (EnvOnly, for user-authored bodies). GLEAN_LEGACY_APIS=1 routes straight to LegacyRun and skips parsing the payload against the platform request type. LegacyRun receives the normalized snake_case payload — the CLI's canonical input shape.

Every namespace migrating to the platform APIs gets this protocol for free; agents (next PR) is the first consumer.

Part 5/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)