### PR TITLE
feat(agenthelp): runtime agent-doc collection from the cobra tree

### DIFF
--- a/cmd/agents.go
+++ b/cmd/agents.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 
 	glean "github.com/gleanwork/api-client-go"
@@ -11,10 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// agentIDRequest is a CLI-only request struct for commands that take an agent
-// ID as their only input. Using camelCase JSON tag for CLI consistency.
+// agentIDRequest is a CLI-only request struct for commands whose only input
+// is an agent ID. The snake_case tag matches the platform input shape;
+// cmdutil transparently normalizes camelCase agentId.
 type agentIDRequest struct {
-	AgentID string `json:"agentId"`
+	AgentID string `json:"agent_id"`
+}
+
+// agentRunRequest is the CLI request for `agents run`. The platform route
+// takes the agent ID as a path parameter (POST /api/agents/{agent_id}/runs),
+// so the CLI folds it into the --json body alongside the run inputs.
+type agentRunRequest struct {
+	AgentID  string                       `json:"agent_id"`
+	Input    map[string]any               `json:"input,omitempty"`
+	Messages []components.PlatformMessage `json:"messages,omitempty"`
+	Metadata map[string]any               `json:"metadata,omitempty"`
 }
 
 func NewCmdAgents() *cobra.Command {
@@ -25,11 +38,19 @@ func NewCmdAgents() *cobra.Command {
 
 Agents are AI-powered workflows that can search, reason, and act on your company's knowledge.
 
+Agent commands are served by the platform API (/api/agents/...) and responses
+use its snake_case shape. list/get/schemas fall back to the classic API with a
+warning when the platform API is not enabled; run does not fall back
+automatically because its request body differs between the two surfaces. Set
+GLEAN_LEGACY_APIS=1 to use the classic API directly (run then expects the
+classic messages/fragments body).
+
 Example:
   glean agents list
-  glean agents get --json '{"agentId":"<id>"}'
-  glean agents schemas --json '{"agentId":"<id>"}'
-  glean agents run --json '{"agentId":"<id>","messages":[{"author":"USER","fragments":[{"text":"summarize Q1 results"}]}]}'`,
+  glean agents get --json '{"agent_id":"<id>"}'
+  glean agents schemas --json '{"agent_id":"<id>"}'
+  glean agents run --json '{"agent_id":"<id>","input":{"query":"summarize Q1 results"}}'
+  glean agents run --json '{"agent_id":"<id>","messages":[{"role":"user","content":[{"type":"text","text":"summarize Q1 results"}]}]}'`,
 	}
 	cmd.AddCommand(
 		newAgentsListCmd(),
@@ -40,26 +61,56 @@ Example:
 	return cmd
 }
 
+// agentsListTextFn renders whichever agents list shape the request produced:
+// the platform response (default) or the classic response (legacy fallback).
+func agentsListTextFn(w io.Writer, v any) error {
+	header := []string{"ID", "NAME", "DESCRIPTION"}
+	switch resp := v.(type) {
+	case *components.PlatformAgentsSearchResponse:
+		rows := make([][]string, len(resp.Agents))
+		for i, a := range resp.Agents {
+			desc := ""
+			if a.Description != nil {
+				desc = output.Truncate(*a.Description, 60)
+			}
+			rows[i] = []string{a.AgentID, a.Name, desc}
+		}
+		return output.WriteTable(w, header, rows)
+	case *components.SearchAgentsResponse:
+		rows := make([][]string, len(resp.Agents))
+		for i, a := range resp.Agents {
+			desc := ""
+			if a.Description != nil {
+				desc = output.Truncate(*a.Description, 60)
+			}
+			rows[i] = []string{a.AgentID, a.Name, desc}
+		}
+		return output.WriteTable(w, header, rows)
+	default:
+		return output.WriteJSON(w, v)
+	}
+}
+
 func newAgentsListCmd() *cobra.Command {
-	return cmdutil.Build(cmdutil.Spec[components.SearchAgentsRequest]{
-		Use:   "list",
-		Short: "List available agents",
-		TextFn: func(w io.Writer, v any) error {
-			resp, ok := v.(*components.SearchAgentsResponse)
-			if !ok {
-				return output.WriteJSON(w, v)
+	return cmdutil.Build(cmdutil.Spec[components.PlatformAgentsSearchRequest]{
+		Use:      "list",
+		Short:    "List available agents",
+		Endpoint: "/api/agents/search",
+		TextFn:   agentsListTextFn,
+		Run: func(ctx context.Context, sdk *glean.Glean, req components.PlatformAgentsSearchRequest) (any, error) {
+			resp, err := sdk.Agents.Search(ctx, req)
+			if err != nil {
+				return nil, err
 			}
-			rows := make([][]string, len(resp.Agents))
-			for i, a := range resp.Agents {
-				desc := ""
-				if a.Description != nil {
-					desc = output.Truncate(*a.Description, 60)
-				}
-				rows[i] = []string{a.AgentID, a.Name, desc}
-			}
-			return output.WriteTable(w, []string{"ID", "NAME", "DESCRIPTION"}, rows)
+			return resp.PlatformAgentsSearchResponse, nil
 		},
-		Run: func(ctx context.Context, sdk *glean.Glean, req components.SearchAgentsRequest) (any, error) {
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			var req components.SearchAgentsRequest
+			if len(rawJSON) > 0 {
+				if err := json.Unmarshal(rawJSON, &req); err != nil {
+					return nil, fmt.Errorf("invalid --json: %w", err)
+				}
+			}
 			resp, err := sdk.Client.Agents.List(ctx, req)
 			if err != nil {
 				return nil, err
@@ -69,12 +120,34 @@ func newAgentsListCmd() *cobra.Command {
 	})
 }
 
+// parseAgentIDRequest is the shared LegacyRun payload parse for get/schemas:
+// the input is a bare agent ID, identical on both surfaces.
+func parseAgentIDRequest(rawJSON []byte) (agentIDRequest, error) {
+	var req agentIDRequest
+	if err := json.Unmarshal(rawJSON, &req); err != nil {
+		return req, fmt.Errorf("invalid --json: %w", err)
+	}
+	return req, nil
+}
+
 func newAgentsGetCmd() *cobra.Command {
 	return cmdutil.Build(cmdutil.Spec[agentIDRequest]{
 		Use:          "get",
 		Short:        "Get an agent by ID",
 		JSONRequired: true,
+		Endpoint:     "/api/agents/{agent_id}",
 		Run: func(ctx context.Context, sdk *glean.Glean, req agentIDRequest) (any, error) {
+			resp, err := sdk.Agents.Get(ctx, req.AgentID)
+			if err != nil {
+				return nil, err
+			}
+			return resp.PlatformAgentGetResponse, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			req, err := parseAgentIDRequest(rawJSON)
+			if err != nil {
+				return nil, err
+			}
 			resp, err := sdk.Client.Agents.Retrieve(ctx, req.AgentID, nil, nil)
 			if err != nil {
 				return nil, err
@@ -89,7 +162,19 @@ func newAgentsSchemasCmd() *cobra.Command {
 		Use:          "schemas",
 		Short:        "Get the schemas for an agent",
 		JSONRequired: true,
+		Endpoint:     "/api/agents/{agent_id}/schemas",
 		Run: func(ctx context.Context, sdk *glean.Glean, req agentIDRequest) (any, error) {
+			resp, err := sdk.Agents.GetSchemas(ctx, req.AgentID, nil)
+			if err != nil {
+				return nil, err
+			}
+			return resp.PlatformAgentSchemasResponse, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			req, err := parseAgentIDRequest(rawJSON)
+			if err != nil {
+				return nil, err
+			}
 			resp, err := sdk.Client.Agents.RetrieveSchemas(ctx, req.AgentID, nil, nil)
 			if err != nil {
 				return nil, err
@@ -100,11 +185,34 @@ func newAgentsSchemasCmd() *cobra.Command {
 }
 
 func newAgentsRunCmd() *cobra.Command {
-	return cmdutil.Build(cmdutil.Spec[components.AgentRunCreate]{
+	return cmdutil.Build(cmdutil.Spec[agentRunRequest]{
 		Use:          "run",
 		Short:        "Run an agent (synchronous)",
 		JSONRequired: true,
-		Run: func(ctx context.Context, sdk *glean.Glean, req components.AgentRunCreate) (any, error) {
+		Endpoint:     "/api/agents/{agent_id}/runs",
+		// The run body is user-authored and shaped differently on the two
+		// surfaces (platform input/messages vs classic messages/fragments),
+		// so gate-closed errors instead of silently replaying the payload.
+		FallbackMode: cmdutil.FallbackEnvOnly,
+		Run: func(ctx context.Context, sdk *glean.Glean, req agentRunRequest) (any, error) {
+			if req.AgentID == "" {
+				return nil, fmt.Errorf("agent_id is required in the --json payload")
+			}
+			resp, err := sdk.Agents.CreateRun(ctx, req.AgentID, components.PlatformAgentRunCreateRequest{
+				Input:    req.Input,
+				Messages: req.Messages,
+				Metadata: req.Metadata,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp.PlatformAgentRunWaitResponse, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			var req components.AgentRunCreate
+			if err := json.Unmarshal(rawJSON, &req); err != nil {
+				return nil, fmt.Errorf("invalid --json: %w", err)
+			}
 			resp, err := sdk.Client.Agents.Run(ctx, req)
 			if err != nil {
 				return nil, err

--- a/cmd/agents_test.go
+++ b/cmd/agents_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gkampitakis/go-snaps/snaps"
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/gleanwork/glean-cli/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,7 @@ func TestAgentsHelp(t *testing.T) {
 // list
 
 func TestAgentsListDryRun(t *testing.T) {
+	usePlatformAPIs(t)
 	// Dry-run must not require auth — SDK init is deferred until after the dry-run check.
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
@@ -36,6 +38,7 @@ func TestAgentsListDryRun(t *testing.T) {
 }
 
 func TestAgentsListInvalidJSON(t *testing.T) {
+	usePlatformAPIs(t)
 	cmd := NewCmdAgents()
 	cmd.SetErr(bytes.NewBufferString(""))
 	cmd.SetArgs([]string{"list", "--json", "not valid json"})
@@ -43,8 +46,9 @@ func TestAgentsListInvalidJSON(t *testing.T) {
 	assert.Error(t, err, "invalid JSON must return error")
 }
 
-func TestAgentsListLive(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+func TestAgentsListLive_UsesPlatformAPI(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, []byte(`{"agents":[],"request_id":"req-1"}`))
 	defer cleanup()
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
@@ -52,9 +56,49 @@ func TestAgentsListLive(t *testing.T) {
 	cmd.SetArgs([]string{"list"})
 	err := cmd.Execute()
 	require.NoError(t, err)
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, "/api/agents/search", mock.Requests[0].URL.Path)
+}
+
+func TestAgentsListGateClosedFallsBack(t *testing.T) {
+	usePlatformAPIs(t)
+	platform.ResetWarnings()
+	mock, cleanup := testutils.SetupTestWithResponse(t, nil)
+	defer cleanup()
+	mock.Routes = map[string]testutils.MockResponse{
+		"/api/agents/search":         gateClosedResponse(),
+		"/rest/api/v1/agents/search": {Body: []byte(`{"agents":[{"agent_id":"legacy-agent","name":"Legacy Agent","capabilities":{}}]}`)},
+	}
+
+	b := bytes.NewBufferString("")
+	errBuf := bytes.NewBufferString("")
+	cmd := NewCmdAgents()
+	cmd.SetOut(b)
+	cmd.SetErr(errBuf)
+	cmd.SetArgs([]string{"list"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, b.String(), "legacy-agent")
+	assert.Contains(t, errBuf.String(), "falling back to the legacy API")
+	require.Len(t, mock.Requests, 2)
+	assert.Equal(t, "/api/agents/search", mock.Requests[0].URL.Path)
+	assert.Equal(t, "/rest/api/v1/agents/search", mock.Requests[1].URL.Path)
+}
+
+func TestAgentsListLegacyEnv(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	mock, cleanup := testutils.SetupTestWithResponse(t, []byte(`{"agents":[]}`))
+	defer cleanup()
+	cmd := NewCmdAgents()
+	cmd.SetOut(bytes.NewBufferString(""))
+	cmd.SetArgs([]string{"list"})
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, "/rest/api/v1/agents/search", mock.Requests[0].URL.Path)
 }
 
 func TestAgentsListFields(t *testing.T) {
+	usePlatformAPIs(t)
 	body, _ := json.Marshal(map[string]any{
 		"agents": []map[string]any{
 			{"agent_id": "agent-1", "name": "Research Agent", "capabilities": map[string]any{}},
@@ -79,6 +123,7 @@ func TestAgentsListFields(t *testing.T) {
 }
 
 func TestAgentsListOutputText(t *testing.T) {
+	usePlatformAPIs(t)
 	body, _ := json.Marshal(map[string]any{
 		"agents": []map[string]any{
 			{"agent_id": "agent-1", "name": "Research Agent", "description": "Finds things", "capabilities": map[string]any{}},
@@ -103,7 +148,9 @@ func TestAgentsListOutputText(t *testing.T) {
 // get
 
 func TestAgentsGetDryRun(t *testing.T) {
+	usePlatformAPIs(t)
 	// Dry-run must not require auth — SDK init is deferred until after the dry-run check.
+	// camelCase agentId input is normalized to the canonical snake_case shape.
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
 	cmd.SetOut(b)
@@ -112,9 +159,9 @@ func TestAgentsGetDryRun(t *testing.T) {
 	require.NoError(t, err)
 	var req map[string]any
 	require.NoError(t, json.Unmarshal(b.Bytes(), &req), "dry-run output must be valid JSON")
-	assert.Equal(t, "test-agent", req["agentId"])
+	assert.Equal(t, "test-agent", req["agent_id"])
 	snaps.MatchInlineSnapshot(t, b.String(), snaps.Inline(`{
-  "agentId": "test-agent"
+  "agent_id": "test-agent"
 }
 `))
 }
@@ -129,6 +176,7 @@ func TestAgentsGetMissingJSON(t *testing.T) {
 }
 
 func TestAgentsGetInvalidJSON(t *testing.T) {
+	usePlatformAPIs(t)
 	cmd := NewCmdAgents()
 	cmd.SetErr(bytes.NewBufferString(""))
 	cmd.SetArgs([]string{"get", "--json", "not valid json"})
@@ -136,8 +184,9 @@ func TestAgentsGetInvalidJSON(t *testing.T) {
 	assert.Error(t, err, "invalid JSON must return error")
 }
 
-func TestAgentsGetLive(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+func TestAgentsGetLive_UsesPlatformAPI(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, []byte(`{"agent":{"agent_id":"test-agent","name":"Test","capabilities":{}},"request_id":"req-1"}`))
 	defer cleanup()
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
@@ -145,11 +194,14 @@ func TestAgentsGetLive(t *testing.T) {
 	cmd.SetArgs([]string{"get", "--json", `{"agentId":"test-agent"}`})
 	err := cmd.Execute()
 	require.NoError(t, err)
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, "/api/agents/test-agent", mock.Requests[0].URL.Path)
 }
 
 // schemas
 
 func TestAgentsSchemasDryRun(t *testing.T) {
+	usePlatformAPIs(t)
 	// Dry-run must not require auth — SDK init is deferred until after the dry-run check.
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
@@ -158,7 +210,7 @@ func TestAgentsSchemasDryRun(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 	snaps.MatchInlineSnapshot(t, b.String(), snaps.Inline(`{
-  "agentId": "test-agent"
+  "agent_id": "test-agent"
 }
 `))
 }
@@ -173,6 +225,7 @@ func TestAgentsSchemasMissingJSON(t *testing.T) {
 }
 
 func TestAgentsSchemasInvalidJSON(t *testing.T) {
+	usePlatformAPIs(t)
 	cmd := NewCmdAgents()
 	cmd.SetErr(bytes.NewBufferString(""))
 	cmd.SetArgs([]string{"schemas", "--json", "not valid json"})
@@ -180,8 +233,9 @@ func TestAgentsSchemasInvalidJSON(t *testing.T) {
 	assert.Error(t, err, "invalid JSON must return error")
 }
 
-func TestAgentsSchemasLive(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+func TestAgentsSchemasLive_UsesPlatformAPI(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
 	defer cleanup()
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
@@ -189,11 +243,14 @@ func TestAgentsSchemasLive(t *testing.T) {
 	cmd.SetArgs([]string{"schemas", "--json", `{"agentId":"test-agent"}`})
 	err := cmd.Execute()
 	require.NoError(t, err)
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, "/api/agents/test-agent/schemas", mock.Requests[0].URL.Path)
 }
 
 // run
 
 func TestAgentsRunDryRun(t *testing.T) {
+	usePlatformAPIs(t)
 	// Dry-run must not require auth — SDK init is deferred until after the dry-run check.
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
@@ -219,6 +276,7 @@ func TestAgentsRunMissingJSON(t *testing.T) {
 }
 
 func TestAgentsRunInvalidJSON(t *testing.T) {
+	usePlatformAPIs(t)
 	cmd := NewCmdAgents()
 	cmd.SetErr(bytes.NewBufferString(""))
 	cmd.SetArgs([]string{"run", "--json", "not valid json"})
@@ -226,13 +284,62 @@ func TestAgentsRunInvalidJSON(t *testing.T) {
 	assert.Error(t, err, "invalid JSON must return error")
 }
 
-func TestAgentsRunLive(t *testing.T) {
+func TestAgentsRunMissingAgentID(t *testing.T) {
+	usePlatformAPIs(t)
 	_, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
 	defer cleanup()
+	cmd := NewCmdAgents()
+	cmd.SetErr(bytes.NewBufferString(""))
+	cmd.SetArgs([]string{"run", "--json", `{"input":{"query":"hi"}}`})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent_id is required")
+}
+
+func TestAgentsRunLive_UsesPlatformAPI(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+	defer cleanup()
+	// The platform run op negotiates streaming in its Accept header; pin the
+	// mock's Content-Type so the SDK parses the buffered JSON response.
+	mock.ContentType = "application/json"
 	b := bytes.NewBufferString("")
 	cmd := NewCmdAgents()
 	cmd.SetOut(b)
-	cmd.SetArgs([]string{"run", "--json", `{"agent_id":"test-agent","messages":[]}`})
+	cmd.SetArgs([]string{"run", "--json", `{"agent_id":"test-agent","input":{"query":"hi"}}`})
 	err := cmd.Execute()
 	require.NoError(t, err)
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, "/api/agents/test-agent/runs", mock.Requests[0].URL.Path)
+}
+
+func TestAgentsRunGateClosedErrors(t *testing.T) {
+	usePlatformAPIs(t)
+	platform.ResetWarnings()
+	mock, cleanup := testutils.SetupTestWithResponse(t, nil)
+	defer cleanup()
+	mock.Routes = map[string]testutils.MockResponse{
+		"/api/agents/test-agent/runs": gateClosedResponse(),
+	}
+	cmd := NewCmdAgents()
+	cmd.SetOut(bytes.NewBufferString(""))
+	cmd.SetErr(bytes.NewBufferString(""))
+	cmd.SetArgs([]string{"run", "--json", `{"agent_id":"test-agent","input":{"query":"hi"}}`})
+	err := cmd.Execute()
+	require.Error(t, err, "run must not silently fall back to the legacy body shape")
+	assert.Contains(t, err.Error(), platform.EnvLegacy)
+	require.Len(t, mock.Requests, 1, "no legacy retry for agents run")
+}
+
+func TestAgentsRunLegacyEnv(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	mock, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+	defer cleanup()
+	cmd := NewCmdAgents()
+	cmd.SetOut(bytes.NewBufferString(""))
+	cmd.SetArgs([]string{"run", "--json", `{"agent_id":"test-agent","messages":[{"author":"USER","fragments":[{"text":"hi"}]}]}`})
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, "/rest/api/v1/agents/runs/wait", mock.Requests[0].URL.Path)
 }

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -12,28 +12,28 @@ func init() {
 	// Register schemas for all commands at startup.
 	schema.Register(schema.CommandSchema{
 		Command:     "search",
-		Description: "Search for content in your Glean instance. Results are JSON.",
+		Description: "Search for content in your Glean instance via the platform API (POST /api/search); responses use its snake_case shape. Falls back to the classic API with a warning when the platform API is not enabled; GLEAN_LEGACY_APIS=1 forces the classic API. Results are JSON.",
 		Flags: map[string]schema.FlagSchema{
-			"--json":                          {Type: "string", Description: "Complete JSON request body (overrides individual flags)", Required: false},
+			"--json":                          {Type: "string", Description: "Complete JSON request body in the platform shape: query, page_size, cursor, datasources, datasource_instances, filters, time_range (overrides individual flags). With GLEAN_LEGACY_APIS=1, parsed as the classic shape", Required: false},
 			"--query":                         {Type: "string", Description: "Search query (positional arg)", Required: true},
 			"--page-size":                     {Type: "integer", Default: 10, Description: "Number of results per page"},
-			"--max-snippet-size":              {Type: "integer", Default: 0, Description: "Maximum snippet size in characters"},
+			"--max-snippet-size":              {Type: "integer", Default: 0, Description: "Maximum snippet size in characters (legacy API only)"},
 			"--timeout":                       {Type: "integer", Default: 30000, Description: "Request timeout in milliseconds"},
-			"--disable-spellcheck":            {Type: "boolean", Default: false, Description: "Disable spellcheck"},
+			"--disable-spellcheck":            {Type: "boolean", Default: false, Description: "Disable spellcheck (legacy API only)"},
 			"--datasource":                    {Type: "[]string", Description: "Filter by datasource (repeatable)"},
 			"--type":                          {Type: "[]string", Description: "Filter by document type (repeatable)"},
-			"--tab":                           {Type: "[]string", Description: "Filter by result tab IDs (repeatable)"},
-			"--response-hints":                {Type: "[]string", Default: []string{"RESULTS", "QUERY_METADATA"}, Description: "Response hints"},
-			"--facet-bucket-size":             {Type: "integer", Default: 10, Description: "Maximum facet buckets per result"},
-			"--disable-query-autocorrect":     {Type: "boolean", Default: false, Description: "Disable automatic query corrections"},
-			"--fetch-all-datasource-counts":   {Type: "boolean", Default: false, Description: "Return counts for all datasources"},
-			"--query-overrides-facet-filters": {Type: "boolean", Default: false, Description: "Allow query operators to override facet filters"},
-			"--return-llm-content":            {Type: "boolean", Default: false, Description: "Return expanded LLM-friendly content"},
+			"--tab":                           {Type: "[]string", Description: "Filter by result tab IDs (repeatable, legacy API only)"},
+			"--response-hints":                {Type: "[]string", Default: []string{"RESULTS", "QUERY_METADATA"}, Description: "Response hints (legacy API only)"},
+			"--facet-bucket-size":             {Type: "integer", Default: 10, Description: "Maximum facet buckets per result (legacy API only)"},
+			"--disable-query-autocorrect":     {Type: "boolean", Default: false, Description: "Disable automatic query corrections (legacy API only)"},
+			"--fetch-all-datasource-counts":   {Type: "boolean", Default: false, Description: "Return counts for all datasources (legacy API only)"},
+			"--query-overrides-facet-filters": {Type: "boolean", Default: false, Description: "Allow query operators to override facet filters (legacy API only)"},
+			"--return-llm-content":            {Type: "boolean", Default: false, Description: "Return expanded LLM-friendly content (legacy API only)"},
 			"--output":                        {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json", Description: "Output format"},
 			"--dry-run":                       {Type: "boolean", Default: false, Description: "Print request body without sending"},
 		},
-		Example: `glean search "vacation policy" | jq '.results[].document.title'
-glean search --json '{"query":"Q1 reports","pageSize":5,"datasources":["confluence"]}' | jq .`,
+		Example: `glean search "vacation policy" | jq '.results[].title'
+glean search --json '{"query":"Q1 reports","page_size":5,"datasources":["confluence"]}' | jq .`,
 	})
 
 	schema.Register(schema.CommandSchema{

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -88,14 +88,14 @@ glean shortcuts create --json '{"data":{"inputAlias":"test/link","destinationUrl
 
 	schema.Register(schema.CommandSchema{
 		Command:     "agents",
-		Description: "Manage and run Glean agents. Subcommands: list, get, schemas, run.",
+		Description: "Manage and run Glean agents via the platform API (/api/agents/...). list/get/schemas fall back to the classic API when the platform API is not enabled; run does not (its body shape differs per surface). GLEAN_LEGACY_APIS=1 forces the classic API. Subcommands: list, get, schemas, run.",
 		Flags: map[string]schema.FlagSchema{
-			"--json":    {Type: "string", Description: "JSON request body"},
+			"--json":    {Type: "string", Description: "JSON request body. get/schemas: {\"agent_id\":\"<id>\"}. run: {\"agent_id\":\"<id>\"} plus input (map) or messages ([{role, content:[{type:\"text\",text}]}])"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
 			"--dry-run": {Type: "boolean", Default: false},
 		},
-		Example: `glean agents list | jq '.[].id'
-glean agents run --json '{"agentId":"my-agent","input":{"query":"test"}}'`,
+		Example: `glean agents list | jq '.agents[].agent_id'
+glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	})
 
 	schema.Register(schema.CommandSchema{

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -13,6 +13,8 @@ func init() {
 	schema.Register(schema.CommandSchema{
 		Command:     "search",
 		Description: "Search for content in your Glean instance via the platform API (POST /api/search); responses use its snake_case shape. Falls back to the classic API with a warning when the platform API is not enabled; GLEAN_LEGACY_APIS=1 forces the classic API. Results are JSON.",
+		WhenToUse:   "Find documents, messages, and content across all connected datasources. Start here for any 'find X' task.",
+		Surface:     schema.SurfacePlatform,
 		Flags: map[string]schema.FlagSchema{
 			"--json":                          {Type: "string", Description: "Complete JSON request body in the platform shape: query, page_size, cursor, datasources, datasource_instances, filters, time_range (overrides individual flags). With GLEAN_LEGACY_APIS=1, parsed as the classic shape", Required: false},
 			"--query":                         {Type: "string", Description: "Search query (positional arg)", Required: true},
@@ -39,6 +41,8 @@ glean search --json '{"query":"Q1 reports","page_size":5,"datasources":["conflue
 	schema.Register(schema.CommandSchema{
 		Command:     "chat",
 		Description: "Have a conversation with Glean AI. Streams response to stdout.",
+		WhenToUse:   "Ask Glean AI a question that needs a synthesized, cited answer reasoned over company knowledge, rather than a raw list of results.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "Complete JSON chat request body (overrides individual flags)"},
 			"--message": {Type: "string", Description: "Chat message (positional arg)", Required: true},
@@ -53,6 +57,8 @@ glean chat --json '{"messages":[{"author":"USER","messageType":"CONTENT","fragme
 	schema.Register(schema.CommandSchema{
 		Command:     "api",
 		Description: "Make a raw authenticated HTTP request to any Glean API endpoint. Bare paths default to /rest/api/v1/; /rest/* and /api/* paths are used verbatim. Requests to /api/* (platform APIs) automatically send the X-Glean-Include-Experimental header.",
+		WhenToUse:   "Escape hatch: call any Glean API endpoint directly (classic /rest/api/v1/* or platform /api/*) when no dedicated subcommand exists.",
+		Surface:     schema.SurfaceRaw,
 		Flags: map[string]schema.FlagSchema{
 			"--method":       {Type: "enum", Enum: []string{"GET", "POST", "PUT", "DELETE", "PATCH"}, Default: "GET", Description: "HTTP method"},
 			"--raw-field":    {Type: "string", Description: "JSON request body as a string"},
@@ -70,6 +76,8 @@ glean api /api/search --method POST --raw-field '{"query":"test"}' | jq .results
 	schema.Register(schema.CommandSchema{
 		Command:     "version",
 		Description: "Print the glean CLI version string.",
+		WhenToUse:   "Check the installed CLI version, e.g. before reporting a bug or verifying an upgrade.",
+		Surface:     schema.SurfaceLocal,
 		Flags:       map[string]schema.FlagSchema{},
 		Example:     `glean version`,
 	})
@@ -77,6 +85,8 @@ glean api /api/search --method POST --raw-field '{"query":"test"}' | jq .results
 	schema.Register(schema.CommandSchema{
 		Command:     "shortcuts",
 		Description: "Manage Glean shortcuts (go-links). Subcommands: list, get, create, update, delete.",
+		WhenToUse:   "Create or resolve go-links (short memorable URLs like go/roadmap).",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body (see Glean API docs for shape)"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -89,6 +99,8 @@ glean shortcuts create --json '{"data":{"inputAlias":"test/link","destinationUrl
 	schema.Register(schema.CommandSchema{
 		Command:     "agents",
 		Description: "Manage and run Glean agents via the platform API (/api/agents/...). list/get/schemas fall back to the classic API when the platform API is not enabled; run does not (its body shape differs per surface). GLEAN_LEGACY_APIS=1 forces the classic API. Subcommands: list, get, schemas, run.",
+		WhenToUse:   "Discover and execute Glean agents (AI workflows). Use schemas first to learn an agent's expected input, then run.",
+		Surface:     schema.SurfacePlatform,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body. get/schemas: {\"agent_id\":\"<id>\"}. run: {\"agent_id\":\"<id>\"} plus input (map) or messages ([{role, content:[{type:\"text\",text}]}])"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -101,6 +113,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "documents",
 		Description: "Retrieve and summarize Glean documents. Subcommands: get, get-by-facets, get-permissions, summarize.",
+		WhenToUse:   "Fetch full metadata, permissions, or an AI summary for documents you already identified (e.g. from search results).",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -112,6 +126,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "entities",
 		Description: "List and read Glean entities and people. Subcommands: list, read-people.",
+		WhenToUse:   "Look up people (org info, contact details) or other structured entities.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":   {Type: "string", Description: "JSON request body", Required: true},
 			"--output": {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -122,6 +138,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "collections",
 		Description: "Manage Glean collections. Subcommands: create, delete, update, add-items, delete-item.",
+		WhenToUse:   "Curate sets of documents into named collections.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -133,6 +151,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "pins",
 		Description: "Manage Glean pins. Subcommands: list, get, create, update, remove.",
+		WhenToUse:   "Pin a document to a search query so it always surfaces for that query.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -144,6 +164,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "answers",
 		Description: "Manage Glean answers. Subcommands: list, get, create, update, delete.",
+		WhenToUse:   "Manage curated Q&A answer cards shown for matching queries.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -155,6 +177,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "tools",
 		Description: "List and run Glean tools. Subcommands: list, run.",
+		WhenToUse:   "Discover and execute Glean tools (actions) such as creating tickets or sending messages.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -166,6 +190,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "verification",
 		Description: "Manage document verification. Subcommands: list, verify, remind.",
+		WhenToUse:   "Track and update document freshness verification (verify docs, send reminders).",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body"},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -177,6 +203,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "activity",
 		Description: "Report user activity and feedback. Subcommands: report, feedback.",
+		WhenToUse:   "Report page-view activity events or submit result feedback to improve ranking.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body (required)", Required: true},
 			"--dry-run": {Type: "boolean", Default: false},
@@ -187,6 +215,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "insights",
 		Description: "Retrieve Glean usage insights. Subcommands: get.",
+		WhenToUse:   "Retrieve aggregate usage analytics (search/AI adoption metrics) for the deployment.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body (required)", Required: true},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -198,6 +228,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "messages",
 		Description: "Retrieve Glean messages. Subcommands: get.",
+		WhenToUse:   "Fetch a specific chat/communication message by ID.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":   {Type: "string", Description: "JSON request body (required)", Required: true},
 			"--output": {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},
@@ -208,6 +240,8 @@ glean agents run --json '{"agent_id":"my-agent","input":{"query":"test"}}'`,
 	schema.Register(schema.CommandSchema{
 		Command:     "announcements",
 		Description: "Manage Glean announcements. Subcommands: create, update, delete.",
+		WhenToUse:   "Publish or manage company announcements surfaced in Glean.",
+		Surface:     schema.SurfaceLegacy,
 		Flags: map[string]schema.FlagSchema{
 			"--json":    {Type: "string", Description: "JSON request body (required)", Required: true},
 			"--output":  {Type: "enum", Enum: []string{"json", "ndjson", "text"}, Default: "json"},

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,15 +10,42 @@ import (
 	"github.com/gleanwork/api-client-go/models/components"
 	gleanClient "github.com/gleanwork/glean-cli/internal/client"
 	"github.com/gleanwork/glean-cli/internal/output"
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/gleanwork/glean-cli/internal/search"
 	"github.com/spf13/cobra"
 )
 
+// searchTextFn renders whichever search response shape the request produced:
+// the platform response (default) or the classic response (legacy fallback).
 func searchTextFn(w io.Writer, v any) error {
-	resp, ok := v.(*components.SearchResponse)
-	if !ok {
+	switch resp := v.(type) {
+	case *components.PlatformSearchResponse:
+		return platformSearchTextFn(w, resp)
+	case *components.SearchResponse:
+		return legacySearchTextFn(w, resp)
+	default:
 		return output.WriteJSON(w, v)
 	}
+}
+
+func platformSearchTextFn(w io.Writer, resp *components.PlatformSearchResponse) error {
+	var rows [][]string
+	for _, r := range resp.Results {
+		snippet := ""
+		if len(r.Snippets) > 0 {
+			snippet = r.Snippets[0]
+		}
+		rows = append(rows, []string{
+			output.Truncate(r.Title, 50),
+			r.Datasource,
+			r.URL,
+			output.Truncate(snippet, 60),
+		})
+	}
+	return output.WriteTable(w, []string{"TITLE", "SOURCE", "URL", "SNIPPET"}, rows)
+}
+
+func legacySearchTextFn(w io.Writer, resp *components.SearchResponse) error {
 	var rows [][]string
 	for _, r := range resp.Results {
 		title, source, url, snippet := "", "", "", ""
@@ -70,14 +98,19 @@ func NewCmdSearch() *cobra.Command {
 		Short: "Search for content in your Glean instance",
 		Long: `Search for content in your Glean instance.
 
+Search is served by the platform API (POST /api/search) and results use its
+snake_case response shape. If the platform API is not enabled on your
+instance, the command falls back to the classic API with a warning; set
+GLEAN_LEGACY_APIS=1 to use the classic API directly.
+
 Results are written as JSON to stdout by default, making the output easy to
 pipe to jq or other tools.
 
 Example:
   glean search "vacation policy"
-  glean search "vacation policy" | jq '.results[].document.title'
-  glean search --json '{"query":"Q1 reports","pageSize":5}' | jq .
-  glean search --output ndjson "engineering docs" | head -3 | jq .document.title
+  glean search "vacation policy" | jq '.results[].title'
+  glean search --json '{"query":"Q1 reports","page_size":5}' | jq .
+  glean search --output ndjson "engineering docs" | head -3 | jq .title
   glean search --dry-run "test"`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -85,9 +118,14 @@ Example:
 				return fmt.Errorf("requires a query argument or --json payload")
 			}
 
-			// --json path: parse directly into SearchRequest
+			// --json path: the payload shape is coupled to the endpoint, so a
+			// user-authored body is never replayed against the other surface.
+			// Platform shape by default; classic shape under GLEAN_LEGACY_APIS=1.
 			if jsonPayload != "" {
-				var req components.SearchRequest
+				if platform.Legacy() {
+					return runLegacyJSONSearch(cmd, jsonPayload, dryRun, outputFormat, raw)
+				}
+				var req components.PlatformSearchRequest
 				if err := json.Unmarshal([]byte(jsonPayload), &req); err != nil {
 					return fmt.Errorf("invalid --json payload: %w", err)
 				}
@@ -98,23 +136,14 @@ Example:
 				if err != nil {
 					return err
 				}
-				resp, err := sdk.Client.Search.Query(cmd.Context(), req, nil)
+				resp, err := sdk.Search.Query(cmd.Context(), req)
 				if err != nil {
+					if platform.IsGateClosed(err) {
+						return platform.GateClosedErr("/api/search", err)
+					}
 					return fmt.Errorf("search request failed: %w", err)
 				}
-				// Text output operates on the raw SDK struct directly;
-				// cleansing is redundant since the table selects its own fields.
-				if outputFormat == output.OutputText {
-					return output.WriteFormatted(cmd.OutOrStdout(), resp.SearchResponse, outputFormat, searchTextFn)
-				}
-				var result any = resp.SearchResponse
-				if !raw {
-					result, err = output.CleanseSearchResponse(result)
-					if err != nil {
-						return err
-					}
-				}
-				return output.WriteFormatted(cmd.OutOrStdout(), result, outputFormat, searchTextFn)
+				return output.WriteFormatted(cmd.OutOrStdout(), resp.PlatformSearchResponse, outputFormat, searchTextFn)
 			}
 
 			// flag-based path
@@ -153,31 +182,46 @@ Example:
 			opts.Query = args[0]
 
 			if dryRun {
-				return output.WriteJSON(cmd.OutOrStdout(), search.BuildSearchRequest(opts))
+				if platform.Legacy() {
+					return output.WriteJSON(cmd.OutOrStdout(), search.BuildSearchRequest(opts))
+				}
+				return output.WriteJSON(cmd.OutOrStdout(), search.BuildPlatformSearchRequest(opts))
 			}
 
 			sdk, err := gleanClient.NewFromConfig()
 			if err != nil {
 				return err
 			}
-			resp, err := search.RunSearchSDK(cmd.Context(), opts, sdk)
+			if !platform.Legacy() {
+				if ignored := platformIgnoredFlags(cmd); len(ignored) > 0 {
+					fmt.Fprintf(cmd.ErrOrStderr(),
+						"Note: flags ignored by platform search (legacy-only): %s\n",
+						strings.Join(ignored, ", "))
+				}
+			}
+
+			result, viaLegacy, err := platform.Run(cmd.Context(), cmd.ErrOrStderr(), "/api/search",
+				func(ctx context.Context) (any, error) { return search.RunPlatformSearch(ctx, opts, sdk) },
+				func(ctx context.Context) (any, error) { return search.RunSearchSDK(ctx, opts, sdk) },
+			)
 			if err != nil {
 				return err
 			}
 			// Text output operates on the raw SDK struct directly;
 			// cleansing is redundant since the table selects its own fields.
 			if outputFormat == output.OutputText {
-				return output.WriteFormatted(cmd.OutOrStdout(), resp, outputFormat, searchTextFn)
+				return output.WriteFormatted(cmd.OutOrStdout(), result, outputFormat, searchTextFn)
 			}
-			var result any = resp
-			if !raw {
+			// The classic response carries superfluous properties and is
+			// cleansed unless --raw; platform responses are emitted as-is.
+			if viaLegacy && !raw {
 				result, err = output.CleanseSearchResponse(result)
 				if err != nil {
 					return err
 				}
 			}
 			if fields != "" {
-				if !raw {
+				if viaLegacy && !raw {
 					if stripped := output.WarnStrippedFields(fields); len(stripped) > 0 {
 						fmt.Fprintf(cmd.ErrOrStderr(),
 							"Warning: field(s) %s not available in cleansed output (use --raw for the full response)\n",
@@ -190,11 +234,11 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&jsonPayload, "json", "", "Complete JSON request body (overrides all other flags)")
+	cmd.Flags().StringVar(&jsonPayload, "json", "", "Complete JSON request body in the platform shape (overrides all other flags); with GLEAN_LEGACY_APIS=1, parsed as the classic shape")
 	cmd.Flags().StringVar(&outputFormat, "output", "json", "Output format: json, ndjson, or text")
 	cmd.Flags().StringVar(&fields, "fields", "", "Comma-separated dot-path fields to include (e.g. results.document.title,results.document.url). Results where all projected fields are missing appear as {}")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the request body without sending it")
-	cmd.Flags().BoolVar(&raw, "raw", false, "Output the full SDK response without cleansing")
+	cmd.Flags().BoolVar(&raw, "raw", false, "Output the full SDK response without cleansing (classic API responses only; platform responses are never cleansed)")
 	cmd.Flags().IntVar(&opts.PageSize, "page-size", 10, "Number of results per page")
 	cmd.Flags().IntVar(&opts.MaxSnippetSize, "max-snippet-size", 0, "Maximum size of snippets")
 	cmd.Flags().IntVar(&opts.TimeoutMillis, "timeout", 30000, "Request timeout in milliseconds")
@@ -212,4 +256,63 @@ Example:
 	cmd.Flags().Int("facet-bucket-size", 10, "Maximum number of facet buckets to return")
 
 	return cmd
+}
+
+// platformIgnoredFlags returns the explicitly-set search flags that have no
+// platform API equivalent, so users learn their flag did nothing rather than
+// silently getting unfiltered results.
+func platformIgnoredFlags(cmd *cobra.Command) []string {
+	legacyOnly := []string{
+		"max-snippet-size",
+		"disable-spellcheck",
+		"tab",
+		"response-hints",
+		"facet-bucket-size",
+		"disable-query-autocorrect",
+		"fetch-all-datasource-counts",
+		"query-overrides-facet-filters",
+		"return-llm-content",
+	}
+	var ignored []string
+	for _, name := range legacyOnly {
+		if cmd.Flags().Changed(name) {
+			ignored = append(ignored, "--"+name)
+		}
+	}
+	return ignored
+}
+
+// runLegacyJSONSearch handles --json under GLEAN_LEGACY_APIS=1: the payload
+// is parsed as the classic /rest/api/v1/search request shape and the
+// response is cleansed unless --raw, exactly as before the platform
+// migration.
+func runLegacyJSONSearch(cmd *cobra.Command, jsonPayload string, dryRun bool, outputFormat string, raw bool) error {
+	var req components.SearchRequest
+	if err := json.Unmarshal([]byte(jsonPayload), &req); err != nil {
+		return fmt.Errorf("invalid --json payload: %w", err)
+	}
+	if dryRun {
+		return output.WriteJSON(cmd.OutOrStdout(), req)
+	}
+	sdk, err := gleanClient.NewFromConfig()
+	if err != nil {
+		return err
+	}
+	resp, err := sdk.Client.Search.Query(cmd.Context(), req, nil)
+	if err != nil {
+		return fmt.Errorf("search request failed: %w", err)
+	}
+	// Text output operates on the raw SDK struct directly;
+	// cleansing is redundant since the table selects its own fields.
+	if outputFormat == output.OutputText {
+		return output.WriteFormatted(cmd.OutOrStdout(), resp.SearchResponse, outputFormat, searchTextFn)
+	}
+	var result any = resp.SearchResponse
+	if !raw {
+		result, err = output.CleanseSearchResponse(result)
+		if err != nil {
+			return err
+		}
+	}
+	return output.WriteFormatted(cmd.OutOrStdout(), result, outputFormat, searchTextFn)
 }

--- a/cmd/search_test.go
+++ b/cmd/search_test.go
@@ -5,13 +5,41 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/gleanwork/glean-cli/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// searchResponse builds a minimal Glean SearchResponse JSON body with the given document titles.
-func searchResponse(titles ...string) []byte {
+const (
+	platformSearchPath = "/api/search"
+	legacySearchPath   = "/rest/api/v1/search"
+)
+
+// platformSearchResponse builds a minimal platform search response body with
+// the given result titles.
+func platformSearchResponse(titles ...string) []byte {
+	type result struct {
+		URL        string   `json:"url"`
+		Title      string   `json:"title"`
+		Datasource string   `json:"datasource"`
+		Snippets   []string `json:"snippets,omitempty"`
+	}
+	rs := []result{}
+	for _, title := range titles {
+		rs = append(rs, result{URL: "https://docs.example.com", Title: title, Datasource: "gdrive"})
+	}
+	b, _ := json.Marshal(map[string]any{
+		"results":     rs,
+		"has_more":    false,
+		"next_cursor": nil,
+		"request_id":  "req-test",
+	})
+	return b
+}
+
+// legacySearchResponse builds a minimal classic SearchResponse JSON body with the given document titles.
+func legacySearchResponse(titles ...string) []byte {
 	type doc struct {
 		Title string `json:"title"`
 	}
@@ -28,8 +56,26 @@ func searchResponse(titles ...string) []byte {
 	return b
 }
 
-func TestSearchCommand_BasicQuery(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, searchResponse("Vacation Policy", "Holiday Guide"))
+// gateClosedResponse is the hidden-404 problem detail the platform stack
+// returns when experimental endpoints are not enabled for the tenant.
+func gateClosedResponse() testutils.MockResponse {
+	return testutils.MockResponse{
+		StatusCode:  404,
+		ContentType: "application/problem+json",
+		Body:        []byte(`{"type":"about:blank","title":"Not Found","status":404,"detail":"resource not found","code":"resource_not_found","request_id":"req-gate"}`),
+	}
+}
+
+// usePlatformAPIs pins the test to platform-first behavior regardless of the
+// developer's own GLEAN_LEGACY_APIS setting.
+func usePlatformAPIs(t *testing.T) {
+	t.Helper()
+	t.Setenv(platform.EnvLegacy, "")
+}
+
+func TestSearchCommand_BasicQuery_UsesPlatformAPI(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Vacation Policy", "Holiday Guide"))
 	defer cleanup()
 
 	root := NewCmdRoot()
@@ -39,6 +85,69 @@ func TestSearchCommand_BasicQuery(t *testing.T) {
 	err := root.Execute()
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "Vacation Policy")
+
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, platformSearchPath, mock.Requests[0].URL.Path)
+}
+
+func TestSearchCommand_PlatformOutputNotCleansed(t *testing.T) {
+	usePlatformAPIs(t)
+	_, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Doc"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"search", "doc"})
+	require.NoError(t, root.Execute())
+
+	// Platform responses are emitted as-is: snake_case fields survive.
+	assert.Contains(t, buf.String(), "request_id")
+	assert.Contains(t, buf.String(), "has_more")
+}
+
+func TestSearchCommand_GateClosedFallsBackToLegacy(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, nil)
+	defer cleanup()
+	mock.Routes = map[string]testutils.MockResponse{
+		platformSearchPath: gateClosedResponse(),
+		legacySearchPath:   {Body: legacySearchResponse("Legacy Doc")},
+	}
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"search", "doc"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, buf.String(), "Legacy Doc")
+	assert.Contains(t, errBuf.String(), "falling back to the legacy API")
+
+	require.Len(t, mock.Requests, 2, "platform attempt then legacy fallback")
+	assert.Equal(t, platformSearchPath, mock.Requests[0].URL.Path)
+	assert.Equal(t, legacySearchPath, mock.Requests[1].URL.Path)
+}
+
+func TestSearchCommand_LegacyEnvSkipsPlatform(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	mock, cleanup := testutils.SetupTestWithResponse(t, legacySearchResponse("Legacy Doc"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"search", "doc"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, buf.String(), "Legacy Doc")
+	assert.NotContains(t, errBuf.String(), "Warning")
+	require.Len(t, mock.Requests, 1)
+	assert.Equal(t, legacySearchPath, mock.Requests[0].URL.Path)
 }
 
 func TestSearchCommand_MissingQuery(t *testing.T) {
@@ -52,6 +161,7 @@ func TestSearchCommand_MissingQuery(t *testing.T) {
 }
 
 func TestSearchCommand_DryRun(t *testing.T) {
+	usePlatformAPIs(t)
 	// Dry-run should not require credentials — SDK init is deferred until after the dry-run check.
 	root := NewCmdRoot()
 	buf := &bytes.Buffer{}
@@ -62,42 +172,106 @@ func TestSearchCommand_DryRun(t *testing.T) {
 	var req map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &req), "dry-run output must be valid JSON")
 	assert.Equal(t, "test query", req["query"])
+	assert.Equal(t, float64(10), req["page_size"], "dry-run shows the platform request shape")
 }
 
-func TestSearchCommand_JSONPayload(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, searchResponse("Engineering Docs"))
+func TestSearchCommand_DryRun_LegacyEnv(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"search", "--dry-run", "test query"})
+	require.NoError(t, root.Execute())
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &req))
+	assert.Equal(t, "test query", req["query"])
+	assert.Contains(t, buf.String(), "pageSize", "legacy dry-run shows the classic camelCase shape")
+}
+
+func TestSearchCommand_JSONPayload_Platform(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Engineering Docs"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	buf := &bytes.Buffer{}
+	root.SetOut(buf)
+	root.SetArgs([]string{"search", "--json", `{"query":"engineering","page_size":5}`})
+	err := root.Execute()
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "Engineering Docs")
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, platformSearchPath, mock.Requests[0].URL.Path)
+}
+
+func TestSearchCommand_JSONPayload_GateClosedErrors(t *testing.T) {
+	usePlatformAPIs(t)
+	mock, cleanup := testutils.SetupTestWithResponse(t, nil)
+	defer cleanup()
+	mock.Routes = map[string]testutils.MockResponse{
+		platformSearchPath: gateClosedResponse(),
+	}
+
+	root := NewCmdRoot()
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	root.SetArgs([]string{"search", "--json", `{"query":"engineering"}`})
+	err := root.Execute()
+	require.Error(t, err, "user-authored payloads must not silently fall back")
+	assert.Contains(t, err.Error(), platform.EnvLegacy)
+	require.Len(t, mock.Requests, 1, "no legacy retry for --json payloads")
+}
+
+func TestSearchCommand_JSONPayload_LegacyEnv(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+	mock, cleanup := testutils.SetupTestWithResponse(t, legacySearchResponse("Engineering Docs"))
 	defer cleanup()
 
 	root := NewCmdRoot()
 	buf := &bytes.Buffer{}
 	root.SetOut(buf)
 	root.SetArgs([]string{"search", "--json", `{"query":"engineering","pageSize":5}`})
-	err := root.Execute()
-	require.NoError(t, err)
+	require.NoError(t, root.Execute())
 	assert.Contains(t, buf.String(), "Engineering Docs")
+	require.NotEmpty(t, mock.Requests)
+	assert.Equal(t, legacySearchPath, mock.Requests[0].URL.Path)
+}
+
+func TestSearchCommand_IgnoredFlagsNote(t *testing.T) {
+	usePlatformAPIs(t)
+	_, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Doc"))
+	defer cleanup()
+
+	root := NewCmdRoot()
+	errBuf := &bytes.Buffer{}
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"search", "--facet-bucket-size", "5", "--return-llm-content", "doc"})
+	require.NoError(t, root.Execute())
+
+	assert.Contains(t, errBuf.String(), "flags ignored by platform search")
+	assert.Contains(t, errBuf.String(), "--facet-bucket-size")
+	assert.Contains(t, errBuf.String(), "--return-llm-content")
 }
 
 func TestSearchCommand_OutputText(t *testing.T) {
+	usePlatformAPIs(t)
 	body, _ := json.Marshal(map[string]any{
 		"results": []map[string]any{
 			{
-				"document": map[string]any{
-					"title":      "Vacation Policy",
-					"datasource": "gdrive",
-					"url":        "https://docs.example.com/vacation",
-				},
-				"snippets": []map[string]any{
-					{"text": "All employees are entitled to 20 days PTO"},
-				},
+				"title":      "Vacation Policy",
+				"datasource": "gdrive",
+				"url":        "https://docs.example.com/vacation",
+				"snippets":   []string{"All employees are entitled to 20 days PTO"},
 			},
 			{
-				"document": map[string]any{
-					"title":      "Holiday Guide",
-					"datasource": "confluence",
-					"url":        "https://wiki.example.com/holidays",
-				},
+				"title":      "Holiday Guide",
+				"datasource": "confluence",
+				"url":        "https://wiki.example.com/holidays",
 			},
 		},
+		"has_more":   false,
+		"request_id": "req-test",
 	})
 	_, cleanup := testutils.SetupTestWithResponse(t, body)
 	defer cleanup()
@@ -121,7 +295,8 @@ func TestSearchCommand_OutputText(t *testing.T) {
 }
 
 func TestSearchCommand_OutputNDJSON(t *testing.T) {
-	_, cleanup := testutils.SetupTestWithResponse(t, searchResponse("Doc A", "Doc B"))
+	usePlatformAPIs(t)
+	_, cleanup := testutils.SetupTestWithResponse(t, platformSearchResponse("Doc A", "Doc B"))
 	defer cleanup()
 
 	root := NewCmdRoot()

--- a/internal/agenthelp/agenthelp.go
+++ b/internal/agenthelp/agenthelp.go
@@ -1,0 +1,307 @@
+// Package agenthelp derives agent-facing usage documentation from the live
+// cobra command tree, enriched with the schema registry's semantics
+// (when-to-use guidance, API surface, examples). Because the output is
+// generated from the installed binary at runtime, it is version-accurate by
+// construction — agents should treat it as the source of truth when it
+// differs from static documentation.
+package agenthelp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/gleanwork/glean-cli/internal/client"
+	"github.com/gleanwork/glean-cli/internal/config"
+	"github.com/gleanwork/glean-cli/internal/output"
+	"github.com/gleanwork/glean-cli/internal/platform"
+	"github.com/gleanwork/glean-cli/internal/schema"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Context describes the environment the CLI is running in, so agents can
+// adapt (e.g. run `glean auth login` before anything else, or expect legacy
+// response shapes when the platform opt-out is active).
+type Context struct {
+	Version       string `json:"version"`
+	ServerURL     string `json:"server_url,omitempty"`
+	Authenticated bool   `json:"authenticated"`
+	// AuthType is "api_token" or "oauth" when authenticated.
+	AuthType string `json:"auth_type,omitempty"`
+	// LegacyMode reports the GLEAN_LEGACY_APIS opt-out: platform-first
+	// commands call the classic APIs directly and emit classic shapes.
+	LegacyMode bool `json:"legacy_mode"`
+	// ExperimentalDisabledByEnv reports that X_GLEAN_INCLUDE_EXPERIMENTAL is
+	// explicitly false in the environment, which suppresses the experimental
+	// header inside the SDK and forces platform-first commands into their
+	// legacy fallback.
+	ExperimentalDisabledByEnv bool `json:"experimental_disabled_by_env,omitempty"`
+}
+
+// BuildContext inspects config and environment. It never fails and never
+// requires authentication: missing credentials simply yield
+// Authenticated=false.
+func BuildContext(version string) Context {
+	c := Context{Version: version, LegacyMode: platform.Legacy()}
+	if v, ok := os.LookupEnv("X_GLEAN_INCLUDE_EXPERIMENTAL"); ok && strings.EqualFold(v, "false") {
+		c.ExperimentalDisabledByEnv = true
+	}
+	cfg, err := config.LoadConfig()
+	if err != nil || cfg == nil {
+		return c
+	}
+	c.ServerURL = cfg.GleanServerURL
+	token, authType := client.ResolveToken(cfg)
+	if token == "" {
+		return c
+	}
+	c.Authenticated = true
+	if authType == "" {
+		c.AuthType = "api_token"
+	} else {
+		c.AuthType = "oauth"
+	}
+	return c
+}
+
+// FlagDoc describes one flag of one command. Existence, type, and default
+// come from cobra (the binary is the source of truth); enum values and
+// required-ness are enriched from the schema registry where available.
+type FlagDoc struct {
+	Type        string   `json:"type"`
+	Default     string   `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Required    bool     `json:"required,omitempty"`
+}
+
+// CommandDoc describes one command (and, recursively, its subcommands).
+type CommandDoc struct {
+	Path        string             `json:"path"`
+	Short       string             `json:"short,omitempty"`
+	Long        string             `json:"long,omitempty"`
+	WhenToUse   string             `json:"when_to_use,omitempty"`
+	Surface     string             `json:"surface,omitempty"`
+	Example     string             `json:"example,omitempty"`
+	Flags       map[string]FlagDoc `json:"flags,omitempty"`
+	Subcommands []CommandDoc       `json:"subcommands,omitempty"`
+}
+
+// Collect walks the visible commands under root and merges cobra's ground
+// truth (structure, flags, defaults) with the schema registry's semantics.
+func Collect(root *cobra.Command) []CommandDoc {
+	var docs []CommandDoc
+	for _, cmd := range root.Commands() {
+		if skipCommand(cmd) {
+			continue
+		}
+		docs = append(docs, collectCommand(cmd, cmd.Name()))
+	}
+	sort.Slice(docs, func(i, j int) bool { return docs[i].Path < docs[j].Path })
+	return docs
+}
+
+func skipCommand(cmd *cobra.Command) bool {
+	return cmd.Hidden || cmd.Name() == "help" || cmd.Name() == "completion"
+}
+
+func collectCommand(cmd *cobra.Command, path string) CommandDoc {
+	doc := CommandDoc{
+		Path:  path,
+		Short: cmd.Short,
+		Long:  cmd.Long,
+		Flags: map[string]FlagDoc{},
+	}
+
+	// Registry semantics are keyed by top-level command name.
+	topLevel := strings.SplitN(path, " ", 2)[0]
+	var registered *schema.CommandSchema
+	if s, err := schema.Get(topLevel); err == nil {
+		registered = &s
+		doc.WhenToUse = s.WhenToUse
+		doc.Surface = s.Surface
+		if path == topLevel {
+			doc.Example = s.Example
+		}
+	}
+
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Hidden {
+			return
+		}
+		fd := FlagDoc{
+			Type:        f.Value.Type(),
+			Default:     f.DefValue,
+			Description: f.Usage,
+		}
+		if registered != nil {
+			if rs, ok := registered.Flags["--"+f.Name]; ok {
+				fd.Enum = rs.Enum
+				fd.Required = rs.Required
+			}
+		}
+		doc.Flags["--"+f.Name] = fd
+	})
+
+	for _, sub := range cmd.Commands() {
+		if skipCommand(sub) {
+			continue
+		}
+		doc.Subcommands = append(doc.Subcommands, collectCommand(sub, path+" "+sub.Name()))
+	}
+	sort.Slice(doc.Subcommands, func(i, j int) bool { return doc.Subcommands[i].Path < doc.Subcommands[j].Path })
+	return doc
+}
+
+// Find returns the CommandDoc for a command path like ["agents", "run"].
+func Find(docs []CommandDoc, target []string) (CommandDoc, error) {
+	if len(target) == 0 {
+		return CommandDoc{}, fmt.Errorf("empty command path")
+	}
+	current := docs
+	var found *CommandDoc
+	for depth, name := range target {
+		found = nil
+		for i := range current {
+			parts := strings.Fields(current[i].Path)
+			if parts[len(parts)-1] == name {
+				found = &current[i]
+				break
+			}
+		}
+		if found == nil {
+			return CommandDoc{}, fmt.Errorf("unknown command %q — run 'glean agent-help' for the command map", strings.Join(target[:depth+1], " "))
+		}
+		current = found.Subcommands
+	}
+	return *found, nil
+}
+
+// jsonEnvelope is the --json output shape.
+type jsonEnvelope struct {
+	Context  Context      `json:"context"`
+	Commands []CommandDoc `json:"commands,omitempty"`
+	Command  *CommandDoc  `json:"command,omitempty"`
+}
+
+// Render writes the overview (empty target) or a single command's detail.
+func Render(w io.Writer, ctx Context, docs []CommandDoc, target []string, asJSON bool) error {
+	if len(target) == 0 {
+		if asJSON {
+			return writeJSON(w, jsonEnvelope{Context: ctx, Commands: docs})
+		}
+		renderOverview(w, ctx, docs)
+		return nil
+	}
+	doc, err := Find(docs, target)
+	if err != nil {
+		return err
+	}
+	if asJSON {
+		return writeJSON(w, jsonEnvelope{Context: ctx, Command: &doc})
+	}
+	renderCommand(w, doc)
+	return nil
+}
+
+func writeJSON(w io.Writer, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
+func renderContext(w io.Writer, ctx Context) {
+	auth := "no — run 'glean auth login' or set GLEAN_API_TOKEN"
+	if ctx.Authenticated {
+		auth = "yes (" + ctx.AuthType + ")"
+	}
+	mode := "platform-first (falls back to legacy per endpoint)"
+	if ctx.LegacyMode {
+		mode = "legacy (GLEAN_LEGACY_APIS is set)"
+	} else if ctx.ExperimentalDisabledByEnv {
+		mode = "legacy (X_GLEAN_INCLUDE_EXPERIMENTAL=false suppresses platform endpoints)"
+	}
+	fmt.Fprintf(w, "version: %s\n", ctx.Version)
+	if ctx.ServerURL != "" {
+		fmt.Fprintf(w, "server: %s\n", ctx.ServerURL)
+	}
+	fmt.Fprintf(w, "authenticated: %s\n", auth)
+	fmt.Fprintf(w, "api mode: %s\n", mode)
+}
+
+func renderOverview(w io.Writer, ctx Context, docs []CommandDoc) {
+	fmt.Fprintln(w, "glean — agent-facing usage generated from this binary.")
+	fmt.Fprintln(w, "Treat this output as the source of truth when it differs from static docs.")
+	fmt.Fprintln(w)
+	renderContext(w, ctx)
+	fmt.Fprintln(w)
+
+	rows := make([][]string, 0, len(docs))
+	for _, d := range docs {
+		use := d.WhenToUse
+		if use == "" {
+			use = d.Short
+		}
+		rows = append(rows, []string{d.Path, use, d.Surface})
+	}
+	_ = output.WriteTable(w, []string{"COMMAND", "WHEN TO USE", "API"}, rows)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Next: `glean agent-help <command> [subcommand]` for flags and payload shapes; add --json for machine-readable output.")
+}
+
+func renderCommand(w io.Writer, doc CommandDoc) {
+	fmt.Fprintf(w, "glean %s — %s\n", doc.Path, doc.Short)
+	if doc.Surface != "" {
+		fmt.Fprintf(w, "api surface: %s\n", doc.Surface)
+	}
+	if doc.WhenToUse != "" {
+		fmt.Fprintf(w, "when to use: %s\n", doc.WhenToUse)
+	}
+	if doc.Long != "" && doc.Long != doc.Short {
+		fmt.Fprintf(w, "\n%s\n", strings.TrimSpace(doc.Long))
+	}
+	if len(doc.Flags) > 0 {
+		fmt.Fprintln(w, "\nflags:")
+		names := make([]string, 0, len(doc.Flags))
+		for name := range doc.Flags {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			f := doc.Flags[name]
+			line := fmt.Sprintf("  %s %s", name, f.Type)
+			if f.Required {
+				line += " (required)"
+			}
+			if len(f.Enum) > 0 {
+				line += " [" + strings.Join(f.Enum, "|") + "]"
+			}
+			if f.Default != "" && f.Default != "false" && f.Default != "0" && f.Default != "[]" {
+				line += " (default " + f.Default + ")"
+			}
+			if f.Description != "" {
+				line += " — " + f.Description
+			}
+			fmt.Fprintln(w, line)
+		}
+	}
+	if len(doc.Subcommands) > 0 {
+		fmt.Fprintln(w, "\nsubcommands:")
+		for _, sub := range doc.Subcommands {
+			fmt.Fprintf(w, "  %s — %s\n", sub.Path, sub.Short)
+		}
+	}
+	if doc.Example != "" {
+		fmt.Fprintln(w, "\nexamples:")
+		for _, line := range strings.Split(doc.Example, "\n") {
+			fmt.Fprintf(w, "  %s\n", line)
+		}
+	}
+}

--- a/internal/agenthelp/agenthelp_test.go
+++ b/internal/agenthelp/agenthelp_test.go
@@ -1,0 +1,134 @@
+package agenthelp
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gleanwork/glean-cli/internal/schema"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestTree builds a synthetic cobra tree with a registered schema entry,
+// a hidden command, and a nested subcommand.
+func newTestTree(t *testing.T) *cobra.Command {
+	t.Helper()
+	schema.Register(schema.CommandSchema{
+		Command:     "widgets",
+		Description: "Manage widgets.",
+		WhenToUse:   "Use for all widget lifecycle operations.",
+		Surface:     schema.SurfacePlatform,
+		Flags: map[string]schema.FlagSchema{
+			"--output": {Type: "enum", Enum: []string{"json", "text"}},
+			"--json":   {Type: "string", Required: true},
+		},
+		Example: "glean widgets list",
+	})
+
+	root := &cobra.Command{Use: "glean"}
+	widgets := &cobra.Command{Use: "widgets", Short: "Manage widgets"}
+	list := &cobra.Command{Use: "list", Short: "List widgets", Run: func(*cobra.Command, []string) {}}
+	list.Flags().String("output", "json", "Output format")
+	list.Flags().String("json", "", "JSON request body")
+	widgets.AddCommand(list)
+	hidden := &cobra.Command{Use: "secret", Hidden: true}
+	root.AddCommand(widgets, hidden)
+	return root
+}
+
+func TestCollect_SkipsHiddenAndMergesRegistry(t *testing.T) {
+	docs := Collect(newTestTree(t))
+
+	require.Len(t, docs, 1, "hidden commands are excluded")
+	w := docs[0]
+	assert.Equal(t, "widgets", w.Path)
+	assert.Equal(t, "Use for all widget lifecycle operations.", w.WhenToUse)
+	assert.Equal(t, schema.SurfacePlatform, w.Surface)
+	assert.Equal(t, "glean widgets list", w.Example)
+
+	require.Len(t, w.Subcommands, 1)
+	list := w.Subcommands[0]
+	assert.Equal(t, "widgets list", list.Path)
+	assert.Equal(t, "Use for all widget lifecycle operations.", list.WhenToUse, "subcommands inherit top-level registry semantics")
+
+	// cobra is truth for flag existence/type; registry enriches enum/required.
+	outFlag, ok := list.Flags["--output"]
+	require.True(t, ok)
+	assert.Equal(t, "string", outFlag.Type)
+	assert.Equal(t, []string{"json", "text"}, outFlag.Enum)
+	jsonFlag := list.Flags["--json"]
+	assert.True(t, jsonFlag.Required)
+}
+
+func TestFind(t *testing.T) {
+	docs := Collect(newTestTree(t))
+
+	doc, err := Find(docs, []string{"widgets", "list"})
+	require.NoError(t, err)
+	assert.Equal(t, "widgets list", doc.Path)
+
+	_, err = Find(docs, []string{"nonexistent"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestRender_OverviewText(t *testing.T) {
+	docs := Collect(newTestTree(t))
+	buf := &bytes.Buffer{}
+	ctx := Context{Version: "test", ServerURL: "https://acme-be.glean.com", Authenticated: true, AuthType: "api_token"}
+	require.NoError(t, Render(buf, ctx, docs, nil, false))
+
+	out := buf.String()
+	assert.Contains(t, out, "source of truth")
+	assert.Contains(t, out, "version: test")
+	assert.Contains(t, out, "authenticated: yes (api_token)")
+	assert.Contains(t, out, "widgets")
+	assert.Contains(t, out, "Use for all widget lifecycle operations.")
+}
+
+func TestRender_UnauthenticatedGuidance(t *testing.T) {
+	buf := &bytes.Buffer{}
+	require.NoError(t, Render(buf, Context{Version: "test"}, nil, nil, false))
+	assert.Contains(t, buf.String(), "glean auth login")
+}
+
+func TestRender_JSON(t *testing.T) {
+	docs := Collect(newTestTree(t))
+	buf := &bytes.Buffer{}
+	ctx := Context{Version: "test", LegacyMode: true}
+	require.NoError(t, Render(buf, ctx, docs, []string{"widgets"}, true))
+
+	var envelope struct {
+		Context struct {
+			Version    string `json:"version"`
+			LegacyMode bool   `json:"legacy_mode"`
+		} `json:"context"`
+		Command struct {
+			Path    string `json:"path"`
+			Surface string `json:"surface"`
+		} `json:"command"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &envelope))
+	assert.Equal(t, "test", envelope.Context.Version)
+	assert.True(t, envelope.Context.LegacyMode)
+	assert.Equal(t, "widgets", envelope.Command.Path)
+	assert.Equal(t, schema.SurfacePlatform, envelope.Command.Surface)
+}
+
+func TestBuildContext_NeverLeaksTokenMaterial(t *testing.T) {
+	t.Setenv("GLEAN_SERVER_URL", "https://acme-be.glean.com")
+	t.Setenv("GLEAN_API_TOKEN", "super-secret-token-value")
+	t.Setenv("X_GLEAN_INCLUDE_EXPERIMENTAL", "false")
+
+	ctx := BuildContext("test")
+	assert.True(t, ctx.Authenticated)
+	assert.Equal(t, "api_token", ctx.AuthType)
+	assert.True(t, ctx.ExperimentalDisabledByEnv)
+
+	serialized, err := json.Marshal(ctx)
+	require.NoError(t, err)
+	assert.False(t, strings.Contains(string(serialized), "super-secret"), "context must never contain token material")
+}

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -21,7 +21,23 @@ import (
 	glean "github.com/gleanwork/api-client-go"
 	gleanClient "github.com/gleanwork/glean-cli/internal/client"
 	"github.com/gleanwork/glean-cli/internal/output"
+	"github.com/gleanwork/glean-cli/internal/platform"
 	"github.com/spf13/cobra"
+)
+
+// FallbackMode controls what a platform-first command (Spec.LegacyRun != nil)
+// does when the platform endpoint is gated off (hidden 404).
+type FallbackMode int
+
+const (
+	// FallbackAuto retries via LegacyRun with a one-time warning. Use for
+	// commands whose request the CLI built itself (or whose input is
+	// surface-agnostic, like a bare ID).
+	FallbackAuto FallbackMode = iota
+	// FallbackEnvOnly never retries automatically: gate-closed produces an
+	// actionable error naming GLEAN_LEGACY_APIS. Use for commands whose
+	// --json body is user-authored and coupled to the endpoint's shape.
+	FallbackEnvOnly
 )
 
 // Spec describes a single SDK-backed subcommand.
@@ -33,6 +49,23 @@ type Spec[Req any] struct {
 	// JSONRequired causes an error when --json is absent.
 	// Set false for list/read commands where the request body is optional.
 	JSONRequired bool
+
+	// Endpoint is the platform API path used in fallback warnings and
+	// gate-closed errors (e.g. "/api/agents/search"). Required when
+	// LegacyRun is set.
+	Endpoint string
+
+	// FallbackMode selects the gate-closed behavior when LegacyRun is set.
+	// The zero value is FallbackAuto.
+	FallbackMode FallbackMode
+
+	// LegacyRun, when non-nil, marks this command platform-first: Run is the
+	// platform API call, and LegacyRun serves the classic API instead when
+	// GLEAN_LEGACY_APIS=1 or as the gate-closed fallback (FallbackAuto).
+	// It receives the normalized --json bytes (snake_case keys — the CLI's
+	// canonical input shape) so it can unmarshal the classic request type,
+	// which differs from the platform Req type.
+	LegacyRun func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error)
 
 	// ErrTransform optionally remaps errors returned by json.Unmarshal before
 	// they are surfaced to the user. Use it to replace Go type names in SDK
@@ -50,6 +83,7 @@ type Spec[Req any] struct {
 	// The payload must be the inner component field — NOT the operation wrapper
 	// (e.g. return resp.ListCollectionsResponse, not resp).
 	// Return (nil, nil) for operations with no response body (delete, etc.).
+	// When LegacyRun is set, Run is the platform API call.
 	Run func(ctx context.Context, sdk *glean.Glean, req Req) (any, error)
 }
 
@@ -74,9 +108,18 @@ func Build[Req any](spec Spec[Req]) *cobra.Command {
 				return fmt.Errorf("--json is required\n\nRun '%s --help' for the expected payload format", cmd.CommandPath())
 			}
 
-			var req Req
+			var normalized []byte
 			if jsonPayload != "" {
-				normalized := normalizeKeys([]byte(jsonPayload), aliases)
+				normalized = normalizeKeys([]byte(jsonPayload), aliases)
+			}
+
+			// In legacy mode the payload is parsed by LegacyRun against the
+			// classic request type, so skip the platform-type parse (the two
+			// shapes differ and a legacy payload may not satisfy it).
+			legacyMode := spec.LegacyRun != nil && platform.Legacy()
+
+			var req Req
+			if len(normalized) > 0 && !legacyMode {
 				if err := json.Unmarshal(normalized, &req); err != nil {
 					if spec.ErrTransform != nil {
 						return spec.ErrTransform(err)
@@ -86,6 +129,17 @@ func Build[Req any](spec Spec[Req]) *cobra.Command {
 			}
 
 			if dryRun {
+				if legacyMode {
+					// The classic request type is known only to LegacyRun;
+					// show the normalized payload as-is.
+					payload := map[string]any{}
+					if len(normalized) > 0 {
+						if err := json.Unmarshal(normalized, &payload); err != nil {
+							return fmt.Errorf("invalid --json: %w", err)
+						}
+					}
+					return output.WriteJSON(cmd.OutOrStdout(), payload)
+				}
 				return output.WriteJSON(cmd.OutOrStdout(), req)
 			}
 
@@ -94,7 +148,23 @@ func Build[Req any](spec Spec[Req]) *cobra.Command {
 				return err
 			}
 
-			result, err := spec.Run(cmd.Context(), sdk, req)
+			var result any
+			switch {
+			case spec.LegacyRun == nil:
+				result, err = spec.Run(cmd.Context(), sdk, req)
+			case legacyMode:
+				result, err = spec.LegacyRun(cmd.Context(), sdk, normalized)
+			case spec.FallbackMode == FallbackEnvOnly:
+				result, err = spec.Run(cmd.Context(), sdk, req)
+				if err != nil && platform.IsGateClosed(err) {
+					return platform.GateClosedErr(spec.Endpoint, err)
+				}
+			default: // FallbackAuto
+				result, _, err = platform.Run(cmd.Context(), cmd.ErrOrStderr(), spec.Endpoint,
+					func(ctx context.Context) (any, error) { return spec.Run(ctx, sdk, req) },
+					func(ctx context.Context) (any, error) { return spec.LegacyRun(ctx, sdk, normalized) },
+				)
+			}
 			if err != nil {
 				return err
 			}

--- a/internal/cmdutil/factory_test.go
+++ b/internal/cmdutil/factory_test.go
@@ -1,0 +1,189 @@
+package cmdutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	glean "github.com/gleanwork/api-client-go"
+	"github.com/gleanwork/api-client-go/models/apierrors"
+	"github.com/gleanwork/glean-cli/internal/platform"
+	"github.com/gleanwork/glean-cli/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeReq is a platform-shaped request type with a snake_case JSON tag so
+// buildAliases produces the agentId → agent_id normalization.
+type fakeReq struct {
+	AgentID string `json:"agent_id"`
+}
+
+func gateClosed() error {
+	return &apierrors.PlatformProblemDetailError{Status: http.StatusNotFound}
+}
+
+// execSpec builds the command from spec, executes it with args, and returns
+// stdout, stderr, and the execution error.
+func execSpec(t *testing.T, spec Spec[fakeReq], args ...string) (string, string, error) {
+	t.Helper()
+	_, cleanup := testutils.SetupTestWithResponse(t, []byte(`{}`))
+	defer cleanup()
+
+	cmd := Build(spec)
+	out, errOut := &bytes.Buffer{}, &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(errOut)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestBuild_PlatformFirst_Success(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:      "get",
+		Endpoint: "/api/agents/{agent_id}",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return map[string]string{"via": "platform", "id": req.AgentID}, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			t.Fatal("LegacyRun must not run on platform success")
+			return nil, nil
+		},
+	}
+	out, errOut, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"via": "platform"`)
+	assert.Contains(t, out, `"id": "a-1"`, "camelCase input must normalize to the snake_case platform field")
+	assert.Empty(t, errOut)
+}
+
+func TestBuild_FallbackAuto_GateClosedUsesLegacy(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:      "get",
+		Endpoint: "/api/agents/{agent_id}",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return nil, gateClosed()
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			var m map[string]string
+			require.NoError(t, json.Unmarshal(rawJSON, &m))
+			return map[string]string{"via": "legacy", "id": m["agent_id"]}, nil
+		},
+	}
+	out, errOut, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"via": "legacy"`)
+	assert.Contains(t, out, `"id": "a-1"`, "LegacyRun receives the normalized snake_case payload")
+	assert.Contains(t, errOut, "falling back to the legacy API")
+}
+
+func TestBuild_FallbackEnvOnly_GateClosedErrors(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:          "run",
+		Endpoint:     "/api/agents/{agent_id}/runs",
+		FallbackMode: FallbackEnvOnly,
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return nil, gateClosed()
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			t.Fatal("LegacyRun must not auto-run in EnvOnly mode")
+			return nil, nil
+		},
+	}
+	_, _, err := execSpec(t, spec, "--json", `{"agent_id":"a-1"}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), platform.EnvLegacy)
+	assert.Contains(t, err.Error(), "/api/agents/{agent_id}/runs")
+}
+
+func TestBuild_FallbackEnvOnly_NonGateErrorPassesThrough(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:          "run",
+		Endpoint:     "/api/agents/{agent_id}/runs",
+		FallbackMode: FallbackEnvOnly,
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return nil, &apierrors.PlatformProblemDetailError{Status: http.StatusUnauthorized, Title: "auth required"}
+		},
+	}
+	_, _, err := execSpec(t, spec, "--json", `{"agent_id":"a-1"}`)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), platform.EnvLegacy, "non-404 errors are not gate-closed guidance")
+}
+
+func TestBuild_LegacyEnv_UsesLegacyRunDirectly(t *testing.T) {
+	platform.ResetWarnings()
+	t.Setenv(platform.EnvLegacy, "1")
+
+	spec := Spec[fakeReq]{
+		Use:      "get",
+		Endpoint: "/api/agents/{agent_id}",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			t.Fatal("platform Run must not execute in legacy mode")
+			return nil, nil
+		},
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) {
+			return map[string]string{"via": "legacy"}, nil
+		},
+	}
+	out, errOut, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"via": "legacy"`)
+	assert.Empty(t, errOut, "explicit legacy opt-out produces no warning")
+}
+
+func TestBuild_NoLegacyRun_BehavesClassically(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use: "get",
+		Run: func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) {
+			return map[string]string{"id": req.AgentID}, nil
+		},
+	}
+	out, _, err := execSpec(t, spec, "--json", `{"agent_id":"a-1"}`)
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id": "a-1"`)
+}
+
+func TestBuild_DryRun_PlatformShape(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "")
+
+	spec := Spec[fakeReq]{
+		Use:       "get",
+		Endpoint:  "/api/agents/{agent_id}",
+		Run:       func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) { return nil, nil },
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) { return nil, nil },
+	}
+	out, _, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`, "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"agent_id": "a-1"`)
+}
+
+func TestBuild_DryRun_LegacyEnvShowsNormalizedPayload(t *testing.T) {
+	t.Setenv(platform.EnvLegacy, "1")
+
+	spec := Spec[fakeReq]{
+		Use:       "get",
+		Endpoint:  "/api/agents/{agent_id}",
+		Run:       func(ctx context.Context, sdk *glean.Glean, req fakeReq) (any, error) { return nil, nil },
+		LegacyRun: func(ctx context.Context, sdk *glean.Glean, rawJSON []byte) (any, error) { return nil, nil },
+	}
+	out, _, err := execSpec(t, spec, "--json", `{"agentId":"a-1"}`, "--dry-run")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"agent_id": "a-1"`)
+}

--- a/internal/schema/registry.go
+++ b/internal/schema/registry.go
@@ -20,12 +20,31 @@ type FlagSchema struct {
 	Required    bool     `json:"required,omitempty"`
 }
 
+// Surface values for CommandSchema.Surface.
+const (
+	// SurfacePlatform marks commands served by the platform APIs (/api/*).
+	SurfacePlatform = "platform"
+	// SurfaceLegacy marks commands served by the classic client APIs (/rest/api/v1/*).
+	SurfaceLegacy = "legacy"
+	// SurfaceRaw marks commands that make raw user-directed HTTP requests.
+	SurfaceRaw = "raw"
+	// SurfaceLocal marks commands that never call the Glean API.
+	SurfaceLocal = "local"
+)
+
 // CommandSchema describes one glean command for agent introspection.
 type CommandSchema struct {
-	Command     string                `json:"command"`
-	Description string                `json:"description"`
-	Flags       map[string]FlagSchema `json:"flags"`
-	Example     string                `json:"example"`
+	Command     string `json:"command"`
+	Description string `json:"description"`
+	// WhenToUse is one sentence of agent guidance: the task this command is
+	// the right tool for.
+	WhenToUse string `json:"when_to_use,omitempty"`
+	// Surface names the API family serving the command: one of the Surface*
+	// constants. Commands migrated to the platform APIs flip this to
+	// SurfacePlatform in the same PR.
+	Surface string                `json:"surface,omitempty"`
+	Flags   map[string]FlagSchema `json:"flags"`
+	Example string                `json:"example"`
 }
 
 var (

--- a/internal/search/platform.go
+++ b/internal/search/platform.go
@@ -1,0 +1,72 @@
+package search
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	glean "github.com/gleanwork/api-client-go"
+	"github.com/gleanwork/api-client-go/models/components"
+)
+
+// datasourceField is the facet filter field that both API surfaces route to
+// a dedicated datasource filter instead of the generic filter mechanism.
+const datasourceField = "datasource"
+
+// BuildPlatformSearchRequest converts Options into the platform API's
+// components.PlatformSearchRequest. The platform surface is deliberately
+// narrower than the classic SearchRequest: flags without a platform
+// equivalent are simply not mapped (cmd/search reports those to the user via
+// flags.Changed, which knows what was explicitly set).
+func BuildPlatformSearchRequest(opts *Options) components.PlatformSearchRequest {
+	req := components.PlatformSearchRequest{
+		Query: opts.Query,
+	}
+
+	if opts.PageSize > 0 {
+		pageSize := int64(opts.PageSize)
+		req.PageSize = &pageSize
+	}
+	if opts.Cursor != "" {
+		cursor := opts.Cursor
+		req.Cursor = &cursor
+	}
+
+	if opts.RequestOptions != nil {
+		for _, ff := range opts.RequestOptions.FacetFilters {
+			// Mirror the classic builder: datasource filtering uses the
+			// dedicated field, not the generic filter mechanism.
+			if ff.FieldName == datasourceField {
+				for _, v := range ff.Values {
+					req.Datasources = append(req.Datasources, v.Value)
+				}
+				continue
+			}
+			filter := components.PlatformFilter{Field: ff.FieldName}
+			for _, v := range ff.Values {
+				filter.Values = append(filter.Values, v.Value)
+			}
+			req.Filters = append(req.Filters, filter)
+		}
+	}
+
+	return req
+}
+
+// RunPlatformSearch executes a search against the platform API
+// (POST /api/search) and returns the raw platform response. The classic
+// request carries timeoutMillis in the body; the platform API does not, so
+// --timeout is honored via a context deadline instead.
+func RunPlatformSearch(ctx context.Context, opts *Options, sdk *glean.Glean) (*components.PlatformSearchResponse, error) {
+	if opts.TimeoutMillis > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(opts.TimeoutMillis)*time.Millisecond)
+		defer cancel()
+	}
+
+	result, err := sdk.Search.Query(ctx, BuildPlatformSearchRequest(opts))
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	return result.PlatformSearchResponse, nil
+}

--- a/internal/search/platform_test.go
+++ b/internal/search/platform_test.go
@@ -1,0 +1,88 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	glean "github.com/gleanwork/api-client-go"
+	"github.com/gleanwork/glean-cli/internal/testutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildPlatformSearchRequest_Basic(t *testing.T) {
+	opts := &Options{Query: "vacation policy", PageSize: 25}
+	req := BuildPlatformSearchRequest(opts)
+
+	assert.Equal(t, "vacation policy", req.Query)
+	require.NotNil(t, req.PageSize)
+	assert.Equal(t, int64(25), *req.PageSize)
+	assert.Nil(t, req.Cursor)
+	assert.Empty(t, req.Datasources)
+	assert.Empty(t, req.Filters)
+}
+
+func TestBuildPlatformSearchRequest_ZeroPageSizeOmitted(t *testing.T) {
+	req := BuildPlatformSearchRequest(&Options{Query: "q"})
+	assert.Nil(t, req.PageSize, "unset page size defers to the API default")
+}
+
+func TestBuildPlatformSearchRequest_Cursor(t *testing.T) {
+	req := BuildPlatformSearchRequest(&Options{Query: "q", Cursor: "next-page-token"})
+	require.NotNil(t, req.Cursor)
+	assert.Equal(t, "next-page-token", *req.Cursor)
+}
+
+func TestBuildPlatformSearchRequest_DatasourceUsesDedicatedField(t *testing.T) {
+	opts := &Options{Query: "q", RequestOptions: &RequestOptions{}}
+	AddFacetFilter(opts, "datasource", []string{"confluence", "slack"})
+	AddFacetFilter(opts, "type", []string{"document"})
+
+	req := BuildPlatformSearchRequest(opts)
+
+	assert.Equal(t, []string{"confluence", "slack"}, req.Datasources)
+	require.Len(t, req.Filters, 1)
+	assert.Equal(t, "type", req.Filters[0].Field)
+	assert.Equal(t, []string{"document"}, req.Filters[0].Values)
+}
+
+func TestRunPlatformSearch_HitsPlatformEndpoint(t *testing.T) {
+	body, err := json.Marshal(map[string]any{
+		"results": []map[string]any{{
+			"url":        "https://example.com/doc",
+			"title":      "Example Doc",
+			"datasource": "confluence",
+			"snippets":   []string{"an excerpt"},
+		}},
+		"has_more":   false,
+		"request_id": "req-123",
+	})
+	require.NoError(t, err)
+
+	mock := &testutils.MockTransport{Body: body, ContentType: "application/json"}
+	sdk := glean.New(
+		glean.WithServerURL("https://test-company-be.glean.com"),
+		glean.WithSecurity("test-token"),
+		glean.WithClient(mock),
+	)
+
+	resp, err := RunPlatformSearch(context.Background(), &Options{Query: "example", TimeoutMillis: 5000}, sdk)
+	require.NoError(t, err)
+
+	require.Len(t, mock.Requests, 1)
+	sent := mock.Requests[0]
+	assert.Equal(t, "/api/search", sent.URL.Path)
+	assert.Equal(t, http.MethodPost, sent.Method)
+
+	sentBody, err := io.ReadAll(sent.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(sentBody), `"query":"example"`)
+
+	require.NotNil(t, resp)
+	require.Len(t, resp.Results, 1)
+	assert.Equal(t, "Example Doc", resp.Results[0].Title)
+	assert.Equal(t, "req-123", resp.RequestID)
+}

--- a/internal/search/utils.go
+++ b/internal/search/utils.go
@@ -65,7 +65,7 @@ func BuildSearchRequest(opts *Options) components.SearchRequest {
 			// The Glean API has a dedicated DatasourcesFilter field that must
 			// be used for datasource filtering — the generic FacetFilters
 			// mechanism does not filter by datasource correctly.
-			if ff.FieldName == "datasource" {
+			if ff.FieldName == datasourceField {
 				for _, v := range ff.Values {
 					sdkOpts.DatasourcesFilter = append(sdkOpts.DatasourcesFilter, v.Value)
 				}

--- a/internal/testutils/mock_client.go
+++ b/internal/testutils/mock_client.go
@@ -12,6 +12,17 @@ import (
 	"github.com/gleanwork/glean-cli/internal/config"
 )
 
+// MockResponse is a canned response for a specific request path, used via
+// MockTransport.Routes to give the platform and legacy endpoints different
+// behavior (e.g. platform 404 → legacy 200 fallback tests).
+type MockResponse struct {
+	// StatusCode defaults to 200 when zero
+	StatusCode int
+	Body       []byte
+	// ContentType defaults to the request's Accept header (see Do)
+	ContentType string
+}
+
 // MockTransport implements http.RoundTripper (the Do method expected by glean.HTTPClient).
 // It returns a predefined response body for every request, making it easy to test
 // command output without making real network calls.
@@ -24,6 +35,8 @@ type MockTransport struct {
 	StatusCode int
 	// ContentType defaults to "application/json" when empty
 	ContentType string
+	// Routes overrides the response per request URL path when the path is present
+	Routes map[string]MockResponse
 	// Requests records all requests received for inspection
 	Requests []*http.Request
 }
@@ -33,13 +46,19 @@ func (m *MockTransport) Do(req *http.Request) (*http.Response, error) {
 	if m.Err != nil {
 		return nil, m.Err
 	}
+	body := m.Body
 	statusCode := m.StatusCode
+	contentType := m.ContentType
+	if route, ok := m.Routes[req.URL.Path]; ok {
+		body = route.Body
+		statusCode = route.StatusCode
+		contentType = route.ContentType
+	}
 	if statusCode == 0 {
 		statusCode = 200
 	}
 	// Mirror the Accept header the SDK sends so the SDK can parse its own response.
 	// CreateStream sets Accept: text/plain; Create sets Accept: application/json.
-	contentType := m.ContentType
 	if contentType == "" {
 		if accept := req.Header.Get("Accept"); accept != "" {
 			contentType = accept
@@ -50,7 +69,7 @@ func (m *MockTransport) Do(req *http.Request) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: statusCode,
 		Header:     http.Header{"Content-Type": []string{contentType}},
-		Body:       io.NopCloser(bytes.NewReader(m.Body)),
+		Body:       io.NopCloser(bytes.NewReader(body)),
 	}, nil
 }
 


### PR DESCRIPTION
internal/agenthelp derives agent-facing usage from the live command tree (cobra is truth for structure, flags, defaults) merged with the schema registry, which gains WhenToUse and Surface (platform|legacy|raw|local) fields — populated for all registered commands. Context reports version, server, auth state (presence only, never token material), and whether legacy mode is active via GLEAN_LEGACY_APIS or X_GLEAN_INCLUDE_EXPERIMENTAL=false.

No user-visible command yet; wired up in the next PR as glean agent-help.

Part 7/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)